### PR TITLE
Clarify how to specify UMD export name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Microbundle includes two commands - `build` (the default) and `watch`. Neither r
 ### `microbundle` / `microbundle build`
 
 By default, microbundle will infer the location of your source entry file
-(the root module in your program) from the `module` field in your `package.json`. It will infer the output directory and filename(s) from the `main` field.
+(the root module in your program) from the `module` field in your `package.json`. It will infer the output directory and filename(s) from the `main` field. For UMD builds, microbundle will use a snake case version of the `name` field in your `package.json` for the export name; you can also specify a name via an `amdName` field or the `name` CLI option.
 
 ### `microbundle watch`
 
@@ -72,6 +72,7 @@ Options:
                                             [boolean] [default: true]
   --strict         Enforce undefined global context and add "use
                    strict"                           [default: false]
+	--name					 Specify name exposed in UMD builds        [string]
 ```
 
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -36,6 +36,10 @@ yargs
 		description: 'Enforce undefined global context and add "use strict"',
 		default: false
 	})
+	.option('name', {
+		description: 'Specify name exposed in UMD builds',
+		default: false
+	})
 	.command(
 		['build [entries..]', '$0 [entries..]'],
 		'Build once and exit',


### PR DESCRIPTION
# What this does
- Adds a `name` option to the CLI, which accepts a string.
- Briefly discusses options for specifying UMB export names in the README

# Context
When bundling UMD build, it is often useful to control the export name. For instance, microbundle defaults to a snake_case version of the `name` field in `package.json`, but camelCase is generally preferred in JavaScript. Trying do so myself, I noticed [the line that determines the name](https://github.com/developit/microbundle/blob/11ee0699fa013d81802322d84c645bf9acd02ef5/src/index.js#L229) feeds from two additional sources:
  - `options.name` which seems like it comes from the CLI options, but no such options exists
  - `pkg.amdName` which is not a standard field AFAIK or mentioned in the README

This PR intends to fix both those things. 🙂

_It's worth noting that adding `--name` from the CLI already feeds to `options.name`. This just makes that fact official, rather than implicit._