### PR TITLE
Change default name from snake_case to PascalCase

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "acorn-jsx": "4.1.0",
     "asyncro": "^2.0.1",
     "babel-polyfill": "^6.26.0",
+    "camelcase": "^4.1.0",
     "chalk": "^2.3.0",
     "es6-promisify": "^5.0.0",
     "glob": "^7.1.2",
@@ -53,7 +54,6 @@
     "rollup-plugin-preserve-shebang": "^0.1.3",
     "rollup-plugin-sizes": "^0.4.2",
     "rollup-plugin-uglify": "^2.0.1",
-    "uppercamelcase": "^3.0.0",
     "yargs": "^10.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "rollup-plugin-preserve-shebang": "^0.1.3",
     "rollup-plugin-sizes": "^0.4.2",
     "rollup-plugin-uglify": "^2.0.1",
+    "uppercamelcase": "^3.0.0",
     "yargs": "^10.0.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,13 @@ import gzipSize from 'gzip-size';
 import prettyBytes from 'pretty-bytes';
 import shebangPlugin from 'rollup-plugin-preserve-shebang';
 import flow from 'rollup-plugin-flow';
-import pascalCase from 'uppercamelcase';
+import camelCase from 'camelcase';
 
 const readFile = promisify(fs.readFile);
 const stat = promisify(fs.stat);
 const isDir = name => stat(name).then( stats => stats.isDirectory() ).catch( () => false );
 const isFile = name => stat(name).then( stats => stats.isFile() ).catch( () => false );
-const safeVariableName = name => pascalCase(name.toLowerCase().replace(/((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, ''));
+const safeVariableName = name => camelCase(name.toLowerCase().replace(/((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, ''));
 
 const FORMATS = ['es', 'cjs', 'umd'];
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,13 @@ import gzipSize from 'gzip-size';
 import prettyBytes from 'pretty-bytes';
 import shebangPlugin from 'rollup-plugin-preserve-shebang';
 import flow from 'rollup-plugin-flow';
+import pascalCase from 'uppercamelcase';
 
 const readFile = promisify(fs.readFile);
 const stat = promisify(fs.stat);
 const isDir = name => stat(name).then( stats => stats.isDirectory() ).catch( () => false );
 const isFile = name => stat(name).then( stats => stats.isFile() ).catch( () => false );
-const safeVariableName = name => name.replace(/(?:^[^a-z$_]|([^a-z0-9_$]+))/g, '_');
+const safeVariableName = name => pascalCase(name.toLowerCase().replace(/((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, ''));
 
 const FORMATS = ['es', 'cjs', 'umd'];
 


### PR DESCRIPTION
This changes the default UMD export name from snake_case to PascalCase, per [this comment](https://github.com/developit/microbundle/pull/10#issuecomment-351415227) from another related PR. 🙂 