### PR TITLE
Add Windows support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+environment:
+  nodejs_version: "8"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+build: off
+
+cache:
+  - node_modules

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-polyfill": "^6.26.0",
     "chalk": "^2.3.0",
     "es6-promisify": "^5.0.0",
+    "glob": "^7.1.2",
     "gzip-size": "^4.1.0",
     "pretty-bytes": "^4.0.2",
     "regenerator-runtime": "^0.11.1",


### PR DESCRIPTION
Glob is not supported on Windows by default. So I added `glob` package. Also I added Windows CI (using AppVeyor).
AppVeyor result: https://ci.appveyor.com/project/g-plane/microbundle/build/1.0.1

Fix #20 