### PR TITLE
Change node resolve param to allow cjs modules, prefer mjs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@ function createConfig(options, entry, format) {
 					include: 'node_modules/**'
 				}),
 				useNodeResolve && nodeResolve({
-					modulesOnly: true,
+					module: true,
 					jsnext: true
 				}),
 				es3(),


### PR DESCRIPTION
By changing "modulesOnly" to just "modules", rollup will look for an mjs module by default, but accept and bundle cjs if not. Closes #17 