### PR TITLE
Migrate CLI to Sade

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "bin": "dist/cli.js",
   "scripts": {
     "build": "npm run -s build:babel && npm run -s build:self",
-    "build:babel": "babel-node --presets env src/cli.js --external all --format cjs src/*.js",
+    "build:babel": "babel-node src/cli.js --external all --format cjs src/*.js --presets env",
     "build:self": "node dist/cli.js --external all --format cjs src/*.js",
     "prepare": "npm run -s build",
     "prepare:babel": "babel --presets env src/*.js -d dist && npm t",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rollup-plugin-preserve-shebang": "^0.1.3",
     "rollup-plugin-sizes": "^0.4.2",
     "rollup-plugin-uglify": "^2.0.1",
-    "yargs": "^10.0.3"
+    "sade": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rollup-plugin-preserve-shebang": "^0.1.3",
     "rollup-plugin-sizes": "^0.4.2",
     "rollup-plugin-uglify": "^2.0.1",
-    "sade": "^1.1.1"
+    "sade": "^1.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rollup-plugin-preserve-shebang": "^0.1.3",
     "rollup-plugin-sizes": "^0.4.2",
     "rollup-plugin-uglify": "^2.0.1",
-    "sade": "^1.0.0"
+    "sade": "^1.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,7 +20,7 @@ prog
 	.option('--cwd', 'Use an alternative working directory', '.');
 
 prog
-	.command('build [...entries]', '', { default:true })
+	.command('build [...entries]', '', { default: true })
 	.describe('Build once and exit')
 	.action(run);
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -27,7 +27,13 @@ prog
 	.describe('Rebuilds on any change')
 	.action(opts => run(opts, true));
 
-prog.parse(process.argv);
+// Parse argv; add extra aliases
+prog.parse(process.argv, {
+	alias: {
+		o: ['output', 'd'],
+		i: ['entry', 'entries', 'e']
+	}
+});
 
 function run(options, watch) {
 	options.entries = options._;

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,61 +1,36 @@
 #!/usr/bin/env node
 
-import yargs from 'yargs';
+import sade from 'sade';
 import microbundle from '.';
 
-yargs
-	.option('entry', {
-		type: 'string',
-		alias: ['i', 'e', 'entries'],
-		description: 'Entry module(s)',
-		defaultDescription: '<package.module>'
-	})
-	.option('output', {
-		type: 'string',
-		alias: ['o', 'd'],
-		description: 'Directory to place build files into',
-		defaultDescription: '<dirname(package.main), build/>'
-	})
-	.option('cwd', {
-		type: 'string',
-		description: 'Use an alternative working directory',
-		defaultDescription: '.'
-	})
-	.option('format', {
-		type: 'string',
-		alias: 'f',
-		description: 'Only build specified formats',
-		defaultDescription: 'es,cjs,umd'
-	})
-	.option('compress', {
-		type: 'boolean',
-		description: 'Compress output using UglifyJS',
-		default: true
-	})
-	.option('strict', {
-		description: 'Enforce undefined global context and add "use strict"',
-		default: false
-	})
-	.option('name', {
-		description: 'Specify name exposed in UMD builds',
-		default: false
-	})
-	.command(
-		['build [entries..]', '$0 [entries..]'],
-		'Build once and exit',
-		() => {},
-		argv => run(argv, false)
-	)
-	.command(
-		'watch [entries..]',
-		'Rebuilds on any change',
-		() => {},
-		argv => run(argv, true)
-	)
-	.help()
-	.argv;
+let { version } = require('../package');
+let prog = sade('microbundle');
+
+prog
+	.version(version)
+	.option('--cwd', 'Use an alternative working directory', '.')
+	.option('--entry, -i', 'Entry module(s)')
+	.option('--output, -o', 'Directory to place build files into')
+	.option('--format, -f', 'Only build specified formats', 'es,cjs,umd')
+	.option('--external', `Specify external dependencies, or 'all'`)
+	.option('--compress', 'Compress output using UglifyJS', true)
+	.option('--strict', 'Enforce undefined global context and add "use strict"')
+	.option('--name', 'Specify name exposed in UMD builds');
+
+prog
+	.command('build [entries]', '', { default: true })
+	.describe('Build once and exit')
+	.action(run);
+
+prog
+	.command('watch [entries]')
+	.describe('Rebuilds on any change')
+	.action(opts => run(opts, true));
+
+prog.parse(process.argv);
 
 function run(options, watch) {
+	options.entries = options._;
 	options.watch = watch===true;
 	microbundle(options)
 		.then( output => {

--- a/src/index.js
+++ b/src/index.js
@@ -24,14 +24,12 @@ const isDir = name => stat(name).then( stats => stats.isDirectory() ).catch( () 
 const isFile = name => stat(name).then( stats => stats.isFile() ).catch( () => false );
 const safeVariableName = name => camelCase(name.toLowerCase().replace(/((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, ''));
 
-const FORMATS = ['es', 'cjs', 'umd'];
-
 const WATCH_OPTS = {
 	exclude: 'node_modules/**'
 };
 
 export default async function microbundle(options) {
-	let cwd = options.cwd = resolve(process.cwd(), options.cwd || '.');
+	let cwd = options.cwd = resolve(process.cwd(), options.cwd);
 
 	try {
 		options.pkg = JSON.parse(await readFile(resolve(cwd, 'package.json'), 'utf8'));
@@ -71,7 +69,7 @@ export default async function microbundle(options) {
 
 	options.multipleEntries = entries.length>1;
 
-	let formats = [].concat(options.format || options.formats || FORMATS);
+	let formats = (options.format || options.formats).split(',');
 
 	let steps = [];
 	for (let i=0; i<entries.length; i++) {


### PR DESCRIPTION
Some of the "silent" aliases aren't included yet. They aren't documented in the README or in the CLI itself, so I think this may be a good time to address that?

These are the missing aliases:

* `d` --> `output`
* `entries` --> `entry`
* `e` --> `entry`

If these are really intended, `sade@1.1.0` is able to support that need.

I can also move some of the default values from the `index.js` into the CLI directly. For example, passing down `pkg.module` directly, since it's already there... up to you~!