### PR TITLE
Add target environment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Options:
                                             [boolean] [default: true]
   --strict         Enforce undefined global context and add "use
                    strict"                           [default: false]
-	--name					 Specify name exposed in UMD builds        [string]
+  --name           Specify name exposed in UMD builds        [string]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Options:
                                                 [string] [default: .]
   --format         Only build specified formats
                                        [string] [default: es,cjs,umd]
+  --target         Specify your target environment
+                                             [string] [default: node]
   --compress       Compress output using UglifyJS
                                             [boolean] [default: true]
   --strict         Enforce undefined global context and add "use

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,7 @@ prog
 	.option('--entry, -i', 'Entry module(s)')
 	.option('--output, -o', 'Directory to place build files into')
 	.option('--format, -f', 'Only build specified formats', 'es,cjs,umd')
+	.option('--target', 'Specify your target environment', 'node')
 	.option('--external', `Specify external dependencies, or 'all'`)
 	.option('--compress', 'Compress output using UglifyJS', true)
 	.option('--strict', 'Enforce undefined global context and add "use strict"')

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,8 @@ function createConfig(options, entry, format) {
 				}),
 				useNodeResolve && nodeResolve({
 					module: true,
-					jsnext: true
+					jsnext: true,
+					browser: options.target === 'browser'
 				}),
 				es3(),
 				// We should upstream this to rollup

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ function createConfig(options, entry, format) {
 				useNodeResolve && nodeResolve({
 					module: true,
 					jsnext: true,
-					browser: options.target === 'browser'
+					browser: options.target!=='node'
 				}),
 				es3(),
 				// We should upstream this to rollup


### PR DESCRIPTION
When building isomorphic libraries, it's useful to bundle browser versions of dependencies. The `target` option makes this possible and provides flexibility to make environment-based decisions in the future.