### PR TITLE
Guard against flow transform response

### DIFF
--- a/src/lib/flow-plugin.js
+++ b/src/lib/flow-plugin.js
@@ -5,7 +5,7 @@ export default function fixedFlow(options) {
 	return Object.assign({}, plugin, {
 		transform(code, id) {
 			let ret = plugin.transform(code, id);
-			if (ret.code===code) return null;
+			if (ret && ret.code===code) return null;
 			return ret;
 		}
 	});


### PR DESCRIPTION
Builds started working again fine after this.

Closes #64.