### PR TITLE
Emit bundle events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ export default async function microbundle(options) {
 	}
 
 	if (options.watch) {
-		const emit = options.emit;
+		const onBuild = options.onBuild;
 		return new Promise( (resolve, reject) => {
 			process.stdout.write(chalk.blue(`Watching source, compiling to ${relative(cwd, dirname(options.output))}:\n`));
 			steps.map( options => {
@@ -107,9 +107,6 @@ export default async function microbundle(options) {
 					output: options.outputOptions,
 					watch: WATCH_OPTS
 				}, options.inputOptions)).on('event', e => {
-					if (emit) {
-						process.emit('event', e);
-					}
 					if (e.code==='ERROR' || e.code==='FATAL') {
 						return reject(e);
 					}
@@ -117,6 +114,9 @@ export default async function microbundle(options) {
 						getSizeInfo(options._code, options.outputOptions.file).then( text => {
 							process.stdout.write(`Wrote ${text.trim()}\n`);
 						});
+						if (typeof onBuild=='function') {
+							onBuild(e);
+						}
 					}
 				});
 			});

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ export default async function microbundle(options) {
 	}
 
 	if (options.watch) {
-		const emitEvents = options.emit;
+		const emit = options.emit;
 		return new Promise( (resolve, reject) => {
 			process.stdout.write(chalk.blue(`Watching source, compiling to ${relative(cwd, dirname(options.output))}:\n`));
 			steps.map( options => {
@@ -107,7 +107,7 @@ export default async function microbundle(options) {
 					output: options.outputOptions,
 					watch: WATCH_OPTS
 				}, options.inputOptions)).on('event', e => {
-					if (emitEvents) {
+					if (emit) {
 						process.emit('event', e);
 					}
 					if (e.code==='ERROR' || e.code==='FATAL') {

--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,7 @@ export default async function microbundle(options) {
 	}
 
 	if (options.watch) {
+		const emitEvents = options.emit;
 		return new Promise( (resolve, reject) => {
 			process.stdout.write(chalk.blue(`Watching source, compiling to ${relative(cwd, dirname(options.output))}:\n`));
 			steps.map( options => {
@@ -108,6 +109,9 @@ export default async function microbundle(options) {
 				}, options.inputOptions)).on('event', e => {
 					if (e.code==='ERROR' || e.code==='FATAL') {
 						return reject(e);
+					}
+					if (emitEvents) {
+						process.emit('event', e);
 					}
 					if (e.code==='END') {
 						getSizeInfo(options._code, options.outputOptions.file).then( text => {

--- a/src/index.js
+++ b/src/index.js
@@ -107,11 +107,11 @@ export default async function microbundle(options) {
 					output: options.outputOptions,
 					watch: WATCH_OPTS
 				}, options.inputOptions)).on('event', e => {
-					if (e.code==='ERROR' || e.code==='FATAL') {
-						return reject(e);
-					}
 					if (emitEvents) {
 						process.emit('event', e);
+					}
+					if (e.code==='ERROR' || e.code==='FATAL') {
+						return reject(e);
 					}
 					if (e.code==='END') {
 						getSizeInfo(options._code, options.outputOptions.file).then( text => {


### PR DESCRIPTION
Add the option to emit build events when running microbundle programmatically. This is a feature I'd like to have to notify a connected browser of a change or any build errors that may have occurred.