### PR TITLE
Update README.md - specify output builds in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,16 @@ Just like `microbundle build`, but watches your source files and rebuilds on any
     --sourcemap      Generate source map  (default true)
     -h, --help       Displays this message
 ```
+### Specifying builds in `package.json`
 
+You can specify output builds in a `package.json` as follows:
+
+```
+"main": "dist/foo.js",          // CJS bundle
+"umd:main": "dist/foo.umd.js",  // UMD bundle
+"module": "dist/foo.m.js",      // ES Modules bundle
+"source": "src/foo.js",         // custom entry module (same as 1st arg to microbundle)
+```
 
 ## 🛣 Roadmap
 


### PR DESCRIPTION
It took me a while to figure out how to specify output builds and I think it could be in a README.md

I found out that it is mentioned in #91 so I've made a PR so it's easier to find.