### PR TITLE
Close #80. Add .tsx support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,8 @@ export default async function microbundle(options) {
 
 	options.name = options.name || options.pkg.amdName || safeVariableName(options.pkg.name);
 
-	const jsOrTs = async filename => resolve(cwd, `${filename}${await isFile(resolve(cwd, filename+'.ts')) ? '.ts' : '.js'}`);
+	const jsOrTs = async filename =>
+		resolve(cwd, `${filename}${await isFile(resolve(cwd, filename+'.ts')) ? '.ts' : await isFile(resolve(cwd, filename+'.tsx')) ? '.tsx' : '.js'}`);
 
 	options.input = [];
 	[].concat(
@@ -196,7 +197,7 @@ function createConfig(options, entry, format, writeMeta) {
 		catch (e) {}
 	}
 
-	const useTypescript = extname(entry)==='.ts';
+	const useTypescript = extname(entry)==='.ts' || extname(entry)==='.tsx';
 
 	let config = {
 		inputOptions: {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -44,12 +44,39 @@ basic-ts
   src
     car.ts
     index.ts
+  tsconfig.json
 
 
 Build \\"basicLibTs\\" to dist:
 104 B: basic-lib-ts.js
 97 B: basic-lib-ts.m.js
 180 B: basic-lib-ts.umd.js"
+`;
+
+exports[`fixtures basic-tsx 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+basic-tsx
+  dist
+    basic-lib-tsx.js
+    basic-lib-tsx.js.map
+    basic-lib-tsx.m.js
+    basic-lib-tsx.m.js.map
+    basic-lib-tsx.umd.js
+    basic-lib-tsx.umd.js.map
+    index.d.ts
+  package.json
+  src
+    index.tsx
+  tsconfig.json
+
+
+Build \\"basicLibTsx\\" to dist:
+221 B: basic-lib-tsx.js
+221 B: basic-lib-tsx.m.js
+295 B: basic-lib-tsx.umd.js"
 `;
 
 exports[`fixtures jsx 1`] = `

--- a/test/fixtures/basic-ts/tsconfig.json
+++ b/test/fixtures/basic-ts/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"rootDir": "./src"
+	}
+}

--- a/test/fixtures/basic-tsx/package.json
+++ b/test/fixtures/basic-tsx/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "basic-lib-tsx"
+}

--- a/test/fixtures/basic-tsx/src/index.tsx
+++ b/test/fixtures/basic-tsx/src/index.tsx
@@ -1,0 +1,12 @@
+const h = (tag, props, ...children) => ({ tag, props, children });
+
+export default class Foo {
+	render() {
+		return (
+			<div id="app">
+				<h1>Hello, World!</h1>
+				<p>A JSX demo.</p>
+			</div>
+		);
+	}
+}

--- a/test/fixtures/basic-tsx/tsconfig.json
+++ b/test/fixtures/basic-tsx/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"rootDir": "./src",
+		"jsxFactory": "h",
+		"jsx": "react"
+	}
+}


### PR DESCRIPTION
- Adds `.tsx` support to microbundle and a test
- Fixes failed snapshot of `basic-lib-ts` output by declaring a proper `compilerOptions.rootDir` in `tsconfig.json`. This ensures that TS does on copies the content of the `src` folder into `dist` and not the folder itself.