### PR TITLE
Better output when building fails on CLI

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -13,7 +13,8 @@ const run = opts => {
 			if (typeof(err.code) === 'string') {
 				process.stderr.write('error ' + err.code);
 				process.exit(1);
-			} else {
+			}
+			else {
 				process.exit(err.code || 1);
 			}
 		});

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,8 +9,13 @@ const run = opts => {
 			if (!opts.watch) process.exit(0);
 		})
 		.catch(err => {
-			process.stderr.write(String(err) + '\n');
-			process.exit(err.code || 1);
+			process.stderr.write(String(err.error || err) + '\n');
+			if (typeof(err.code) === 'string') {
+				process.stderr.write('error ' + err.code);
+				process.exit(1);
+			} else {
+				process.exit(err.code || 1);
+			}
 		});
 };
 


### PR DESCRIPTION
Replaces the not-so-useful `[object Object]` error output

![screen shot 2018-04-17 at 2 03 08 pm](https://user-images.githubusercontent.com/612020/38848032-1f945172-4248-11e8-8746-29e62fb02581.png)

```
❯ yarn dev
yarn run v1.6.0
$ microbundle watch
Watching source, compiling to dist:
[object Object]
✨  Done in 1.85s.
```

... with the actual error string when available:

![screen shot 2018-04-17 at 2 01 32 pm](https://user-images.githubusercontent.com/612020/38848044-29505936-4248-11e8-9e65-282d0eae131e.png)

```
❯ yarn dev
yarn run v1.6.0
$ microbundle watch
Watching source, compiling to dist:
SyntaxError: Unexpected token (1:7) /Users/jess/dev/cete/landing-page/components/src/index.js (nodent)
export FukolGrid, { FukolItem } from './fukol-grid';
-------^
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

---

The `yarn dev` command maps to: `microbundle watch`