### PR TITLE
Minify CSS assets with cssnano if compress option is true

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-polyfill": "^6.26.0",
     "camelcase": "^5.0.0",
     "chalk": "^2.3.0",
+    "cssnano": "^3.10.0",
     "es6-promisify": "^6.0.0",
     "glob": "^7.1.2",
     "gzip-size": "^4.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import { map, series } from 'asyncro';
 import glob from 'glob';
 import autoprefixer from 'autoprefixer';
+import cssnano from 'cssnano';
 import { rollup, watch } from 'rollup';
 import nodent from 'rollup-plugin-nodent';
 import commonjs from 'rollup-plugin-commonjs';
@@ -213,8 +214,11 @@ function createConfig(options, entry, format, writeMeta) {
 				}),
 				postcss({
 					plugins: [
-						autoprefixer()
-					],
+						autoprefixer(),
+						options.compress!==false && cssnano({
+							preset: 'default'
+						})
+					].filter(Boolean),
 					// only write out CSS for the first bundle (avoids pointless extra files):
 					inject: false,
 					extract: !!writeMeta

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -25,6 +25,32 @@ Build \\"basicLib\\" to dist:
 300 B: basic-lib.umd.js"
 `;
 
+exports[`fixtures basic-css 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+basic-css
+  dist
+    basic-css.css
+    basic-css.js
+    basic-css.js.map
+    basic-css.m.js
+    basic-css.m.js.map
+    basic-css.umd.js
+    basic-css.umd.js.map
+  package.json
+  src
+    index.js
+    two.css
+
+
+Build \\"basicCss\\" to dist:
+107 B: basic-css.js
+107 B: basic-css.m.js
+188 B: basic-css.umd.js"
+`;
+
 exports[`fixtures basic-ts 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/basic-css/package.json
+++ b/test/fixtures/basic-css/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "basic-css"
+}

--- a/test/fixtures/basic-css/src/index.js
+++ b/test/fixtures/basic-css/src/index.js
@@ -1,0 +1,7 @@
+import './two.css';
+
+export default function () {
+	const el = document.createElement('div')
+	el.className = "testing";
+	return el;
+}

--- a/test/fixtures/basic-css/src/two.css
+++ b/test/fixtures/basic-css/src/two.css
@@ -1,0 +1,5 @@
+.testing {
+	display: flex;
+	color: red;
+	background: blue;
+}


### PR DESCRIPTION
As the name of this PR suggests, this change will minify the CSS assets generated by Microbundle when the "compress" option is true. 

I'm using [cssnano](https://github.com/ben-eb/cssnano) to preform the minification using it's default "safe" mode. This also happens to be the same minifier that Webpack's "css-loader" uses.