### PR TITLE
More helpful rollup errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ import prettyBytes from 'pretty-bytes';
 import shebangPlugin from 'rollup-plugin-preserve-shebang';
 import typescript from 'rollup-plugin-typescript2';
 import flow from './lib/flow-plugin';
-import { readFile, isDir, isFile } from './utils';
+import { readFile, isDir, isFile, stdout, stderr } from './utils';
 import camelCase from 'camelcase';
 
 const removeScope = name => name.replace(/^@.*\//, '');
@@ -39,9 +39,9 @@ export default async function microbundle(options) {
 		options.pkg = JSON.parse(await readFile(resolve(cwd, 'package.json'), 'utf8'));
 	}
 	catch (err) {
-		process.stderr.write(chalk.yellow(`${chalk.yellow.inverse('WARN')} no package.json found. Assuming a pkg.name of "${basename(options.cwd)}".`) + '\n');
+		stderr(chalk.yellow(`${chalk.yellow.inverse('WARN')} no package.json found. Assuming a pkg.name of "${basename(options.cwd)}".`));
 		let msg = String(err.message || err);
-		if (!msg.match(/ENOENT/)) console.warn(`  ${chalk.red.dim(msg)}`);
+		if (!msg.match(/ENOENT/)) stderr(`  ${chalk.red.dim(msg)}`);
 		options.pkg = {};
 		hasPackageJson = false;
 	}
@@ -49,7 +49,7 @@ export default async function microbundle(options) {
 	if (!options.pkg.name) {
 		options.pkg.name = basename(options.cwd);
 		if (hasPackageJson) {
-			process.stderr.write(chalk.yellow(`${chalk.yellow.inverse('WARN')} missing package.json "name" field. Assuming "${options.pkg.name}".`) + '\n');
+			stderr(chalk.yellow(`${chalk.yellow.inverse('WARN')} missing package.json "name" field. Assuming "${options.pkg.name}".`));
 		}
 	}
 
@@ -104,7 +104,7 @@ export default async function microbundle(options) {
 	if (options.watch) {
 		const onBuild = options.onBuild;
 		return new Promise((resolve, reject) => {
-			process.stdout.write(chalk.blue(`Watching source, compiling to ${relative(cwd, dirname(options.output))}:\n`));
+			stdout(chalk.blue(`Watching source, compiling to ${relative(cwd, dirname(options.output))}:`));
 			steps.map(options => {
 				watch(Object.assign({
 					output: options.outputOptions,
@@ -115,7 +115,7 @@ export default async function microbundle(options) {
 					}
 					if (e.code === 'END') {
 						getSizeInfo(options._code, options.outputOptions.file).then(text => {
-							process.stdout.write(`Wrote ${text.trim()}\n`);
+							stdout(`Wrote ${text.trim()}`);
 						});
 						if (typeof onBuild === 'function') {
 							onBuild(e);

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,3 +6,5 @@ export const readFile = promisify(fs.readFile);
 export const stat = promisify(fs.stat);
 export const isDir = name => stat(name).then( stats => stats.isDirectory() ).catch( () => false );
 export const isFile = name => stat(name).then( stats => stats.isFile() ).catch( () => false );
+export const stdout = console.log.bind(console); // eslint-disable-line no-console
+export const stderr = console.error.bind(console);


### PR DESCRIPTION
First of all: __this is just a suggestion__, so feel free to close the PR if you are not interested 😸

This PR handles Rollup errors in a more graceful way (the change copies essential parts of [`rollup/bin/src/logging.ts`](https://github.com/rollup/rollup/blob/master/bin/src/logging.ts), unfortunately, Rollup doesn't export this part of the module to the public). Everything that could help users of the `microbundle` understand the underlying issue with the build is printed to the console.

This is how it looks for the failed build with this change:

![image](https://user-images.githubusercontent.com/5036933/39870183-ac0f0c58-5460-11e8-9f1c-b24e6ce5d9d6.png)

I also switched microbundle from using `process.std(out|err).write` directly to using `console.(log|error)` methods. Console methods are doing the same thing, only the newlines are added automatically by console methods, so you don't need to do this whenever you are printing to the console. This also results in microbundle being a tiny bit (4 KB) smaller now, haha 🎉

