### PR TITLE
Turn off eslint rules inconsistent with prettier settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "eslint-config-developit",
+    "prettier",
+    "plugin:prettier/recommended"
+  ],
+  "plugins": [
+    "prettier"
+  ],
+  "rules": {
+    "brace-style": "off",
+    "comma-dangle": ["warn", "always-multiline"],
+    "indent": "off"
+  }
+}

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,10 +1,6 @@
 module.exports = {
 	linters: {
-		'{src,test}/**/*.js': [
-			'prettier --use-tabs --single-quote --trailing-comma=all --write',
-			'eslint --fix',
-			'git add',
-		],
+		'{src,test}/**/*.js': ['eslint --fix', 'git add'],
 		'*.md': ['prettier --write', 'git add'],
 	},
 	ignore: ['**/dist/**/*.js'],

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,6 +2,7 @@ module.exports = {
 	linters: {
 		'{src,test}/**/*.js': [
 			'prettier --use-tabs --single-quote --trailing-comma=all --write',
+			'eslint --fix',
 			'git add',
 		],
 		'*.md': ['prettier --write', 'git add'],

--- a/package.json
+++ b/package.json
@@ -17,18 +17,15 @@
     "release": "npm run -s prepare && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "repository": "developit/microbundle",
-  "eslintConfig": {
-    "extends": "eslint-config-developit",
-    "rules": {
-      "brace-style": "off",
-      "comma-dangle": ["warn", "always-multiline"],
-      "indent": "off"
-    }
-  },
   "babel": {
     "presets": [
       "env"
     ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all",
+    "useTabs": true
   },
   "keywords": [
     "bundle",
@@ -78,11 +75,13 @@
     "directory-tree": "^2.1.0",
     "eslint": "^4.19.1",
     "eslint-config-developit": "^1.1.1",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-prettier": "^2.6.0",
     "fs-extra": "^5.0.0",
     "husky": "^0.14.3",
     "jest": "^22.4.3",
     "lint-staged": "^7.1.0",
-    "prettier": "^1.12.1",
+    "prettier": "^1.13.0",
     "rimraf": "^2.6.2",
     "shell-quote": "^1.6.1",
     "strip-ansi": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "eslintConfig": {
     "extends": "eslint-config-developit",
     "rules": {
-      "comma-dangle": ["warn", "always-multiline"]
+      "brace-style": "off",
+      "comma-dangle": ["warn", "always-multiline"],
+      "indent": "off"
     }
   },
   "babel": {


### PR DESCRIPTION
Alternatively we can use `prettier-eslint` - this would run eslint with `--fix` right after the `prettier`