### PR TITLE
[FEATURE] [WIP] Add Reason support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 dist
 package-lock.json
 yarn.lock
+test/fixtures/basic-re/lib
+.merlin

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "regenerator-runtime": "^0.11.1",
     "rollup": "0.59.2",
     "rollup-plugin-buble": "^0.19.2",
+    "rollup-plugin-bucklescript": "^0.6.1",
     "rollup-plugin-bundle-size": "^1.0.1",
     "rollup-plugin-commonjs": "^9.0.0",
     "rollup-plugin-es3": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "bs-platform": "^3.1.4",
     "directory-tree": "^2.1.0",
     "eslint": "^4.19.1",
     "eslint-config-developit": "^1.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ export default async function microbundle(options) {
 	options.name =
 		options.name || options.pkg.amdName || safeVariableName(options.pkg.name);
 
-	const jsOrTs = async filename =>
+	const getFileType = async filename =>
 		resolve(
 			cwd,
 			`${filename}${
@@ -84,7 +84,9 @@ export default async function microbundle(options) {
 					? '.ts'
 					: (await isFile(resolve(cwd, filename + '.tsx')))
 						? '.tsx'
-						: '.js'
+						: (await isFile(resolve(cwd, filename + '.re')))
+							? '.re'
+							: '.js'
 			}`,
 		);
 
@@ -94,8 +96,9 @@ export default async function microbundle(options) {
 			options.entries && options.entries.length
 				? options.entries
 				: options.pkg.source ||
-				  ((await isDir(resolve(cwd, 'src'))) && (await jsOrTs('src/index'))) ||
-				  (await jsOrTs('index')) ||
+				  ((await isDir(resolve(cwd, 'src'))) &&
+						(await getFileType('src/index'))) ||
+				  (await getFileType('index')) ||
 				  options.pkg.module,
 		)
 		.map(file => glob(file))

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import gzipSize from 'gzip-size';
 import prettyBytes from 'pretty-bytes';
 import shebangPlugin from 'rollup-plugin-preserve-shebang';
 import typescript from 'rollup-plugin-typescript2';
+import bucklescript from 'rollup-plugin-bucklescript';
 import flow from './lib/flow-plugin';
 import { readFile, isDir, isFile, stdout, stderr } from './utils';
 import camelCase from 'camelcase';
@@ -283,6 +284,7 @@ function createConfig(options, entry, format, writeMeta) {
 	}
 
 	const useTypescript = extname(entry) === '.ts' || extname(entry) === '.tsx';
+	const useReason = extname(entry) === '.re';
 
 	const externalPredicate = new RegExp(`^(${external.join('|')})($|/)`);
 	const externalTest =
@@ -319,7 +321,8 @@ function createConfig(options, entry, format, writeMeta) {
 							typescript: require('typescript'),
 							tsconfigDefaults: { compilerOptions: { declaration: true } },
 						}),
-					!useTypescript && flow({ all: true, pretty: true }),
+					useReason && bucklescript(),
+					!useTypescript && !useReason && flow({ all: true, pretty: true }),
 					nodent({
 						exclude: 'node_modules/**',
 						noRuntime: true,
@@ -334,6 +337,7 @@ function createConfig(options, entry, format, writeMeta) {
 						},
 					}),
 					!useTypescript &&
+						!useReason &&
 						buble({
 							exclude: 'node_modules/**',
 							jsx: options.jsx || 'h',

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -51,6 +51,43 @@ Build \\"basicCss\\" to dist:
 188 B: basic-css.umd.js"
 `;
 
+exports[`fixtures basic-re 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+basic-re
+  bsconfig.json
+  dist
+    basic-reason.js
+    basic-reason.js.map
+    basic-reason.m.js
+    basic-reason.m.js.map
+    basic-reason.umd.js
+    basic-reason.umd.js.map
+  lib
+    bs
+      build.ninja
+      src
+        index.cmi
+        index.cmj
+        index.cmt
+        index.mlast
+        index.mlast.d
+    es6
+      src
+        index.js
+  package.json
+  src
+    index.re
+
+
+Build \\"basicReason\\" to dist:
+76 B: basic-reason.js
+80 B: basic-reason.m.js
+175 B: basic-reason.umd.js"
+`;
+
 exports[`fixtures basic-ts 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/basic-re/bsconfig.json
+++ b/test/fixtures/basic-re/bsconfig.json
@@ -1,0 +1,6 @@
+{
+	"name": "basic-reason",
+	"sources": ["src"],
+	"package-specs": ["es6"],
+	"refmt": 3
+}

--- a/test/fixtures/basic-re/package.json
+++ b/test/fixtures/basic-re/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "basic-lib-reason"
+}

--- a/test/fixtures/basic-re/package.json
+++ b/test/fixtures/basic-re/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "basic-lib-reason"
+  "name": "basic-reason"
 }

--- a/test/fixtures/basic-re/src/index.re
+++ b/test/fixtures/basic-re/src/index.re
@@ -1,0 +1,3 @@
+let add = (x, y) => x + y;
+
+Js.log(add(1, 2));


### PR DESCRIPTION
As discussed in https://github.com/developit/microbundle/issues/141.

This PR adds support for [Reason](https://reasonml.github.io/) (`.re`)

It assumes you have `bs-platform` installed (locally or globally) and have a `bsconfig.json` file at the root of your folder. (see fixture)

Just not sure how to tackle the warnings (as suggested in the issue above). 
Any ideas?