### PR TITLE
Fix #111 and log errors during watch mode

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
 import microbundle from '.';
 import prog from './prog';
-import { stdout, stderr } from './utils';
+import { stdout } from './utils';
+import logError from './log-error';
 
 const run = opts => {
 	microbundle(opts)
@@ -12,31 +12,7 @@ const run = opts => {
 		})
 		.catch(err => {
 			process.exitCode = (typeof err.code === 'number' && err.code) || 1;
-
-			const error = err.error || err;
-			const description = `${
-				error.name ? error.name + ': ' : ''
-			}${error.message || error}`;
-			const message = error.plugin
-				? `(${error.plugin} plugin) ${description}`
-				: description;
-
-			stderr(chalk.bold.red(message));
-
-			if (error.loc) {
-				stderr();
-				stderr(`at ${error.loc.file}:${error.loc.line}:${error.loc.column}`);
-			}
-
-			if (error.frame) {
-				stderr();
-				stderr(chalk.dim(error.frame));
-			} else if (err.stack) {
-				const headlessStack = error.stack.replace(message, '');
-				stderr(chalk.dim(headlessStack));
-			}
-
-			stderr();
+			logError(err);
 			process.exit();
 		});
 };

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import prettyBytes from 'pretty-bytes';
 import shebangPlugin from 'rollup-plugin-preserve-shebang';
 import typescript from 'rollup-plugin-typescript2';
 import flow from './lib/flow-plugin';
+import logError from './log-error';
 import { readFile, isDir, isFile, stdout, stderr } from './utils';
 import camelCase from 'camelcase';
 
@@ -162,8 +163,10 @@ export default async function microbundle(options) {
 						options.inputOptions,
 					),
 				).on('event', e => {
-					if (e.code === 'ERROR' || e.code === 'FATAL') {
-						return reject(e);
+					if (e.code === 'FATAL') {
+						return reject(e.error);
+					} else if (e.code === 'ERROR') {
+						logError(e.error);
 					}
 					if (e.code === 'END') {
 						getSizeInfo(options._code, options.outputOptions.file).then(

--- a/src/log-error.js
+++ b/src/log-error.js
@@ -1,0 +1,28 @@
+import chalk from 'chalk';
+import { stderr } from './utils';
+
+export default function(err) {
+	const error = err.error || err;
+	const description = `${error.name ? error.name + ': ' : ''}${error.message ||
+		error}`;
+	const message = error.plugin
+		? `(${error.plugin} plugin) ${description}`
+		: description;
+
+	stderr(chalk.bold.red(message));
+
+	if (error.loc) {
+		stderr();
+		stderr(`at ${error.loc.file}:${error.loc.line}:${error.loc.column}`);
+	}
+
+	if (error.frame) {
+		stderr();
+		stderr(chalk.dim(error.frame));
+	} else if (err.stack) {
+		const headlessStack = error.stack.replace(message, '');
+		stderr(chalk.dim(headlessStack));
+	}
+
+	stderr();
+}


### PR DESCRIPTION
This PR applies the following:

- Fix #111 
- Ensure that errors during `watch` mode are logged in full, rather than logging `[object Object]` in terminal
- Ensure that fatal errors still trigger build failure, but other error codes should not stop the watch mode
- Pull the logging logic out of `cli.js` into `log-error.js` so that it can be used in `cli.js` and `index.js`