### PR TITLE
Add react-recomponent to "Built with Microbundle"

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Here's what's coming up for Microbundle:
 
 - [Stockroom](https://github.com/developit/stockroom) Offload your store management to a worker easily.
 - [Microenvi](https://github.com/fwilkerson/microenvi) Bundle, serve, and hot reload with one command.
-
+- [react-recomponent](https://github.com/philipp-spiess/react-recomponent) Reason-style reducer components for React using ES6 classes.
 
 ## 🥂 License
 


### PR DESCRIPTION
I'm a huge fan of microbundle and am using it for [react-recomponent](https://github.com/philipp-spiess/react-recomponent) as well. I would be honored to get it mentioned in the README 😊 