### PR TITLE
Switch jest test environment to node

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "trailingComma": "all",
     "useTabs": true
   },
+  "jest": {
+    "testEnvironment": "node"
+  },
   "keywords": [
     "bundle",
     "rollup",


### PR DESCRIPTION
Fixes jest tests failing in master because of the minor version bump in default `jsdom` environment. Root cause of the issue is described in following two issues:

- https://github.com/facebook/jest/issues/6766
- https://github.com/jsdom/jsdom/issues/2304

For `microbundle` it doesn't make sense to run tests in jsdom environment in general, so this PR fixes the issue by setting jest test environment to `node`