### PR TITLE
Better* defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@
 }
 ```
 
-
 ## 📦 Usage
 
 Microbundle includes two commands - `build` (the default) and `watch`. Neither require any options, but you can tailor things to suit your needs a bit if you like.
@@ -42,6 +41,16 @@ Microbundle includes two commands - `build` (the default) and `watch`. Neither r
 
 By default, microbundle will infer the location of your source entry file
 (the root module in your program) from the `source` field in your `package.json`. It will infer the output directory and filename(s) from the `main` field. For UMD builds, microbundle will use a snake case version of the `name` field in your `package.json` for the export name; you can also specify a name via an `amdName` field or the `name` CLI option.
+
+If you'd like to compress your library for distribution, include the `--compress` flag. You may also produce and include source maps by including the `--sourcemap` flag:
+
+```sh
+$ microbundle --compress --sourcemap
+# or
+$ microbundle build --compress --sourcemap
+```
+
+> **Note:** These flags can also be applied to `watch` mode!
 
 ### `microbundle watch`
 
@@ -66,16 +75,17 @@ Just like `microbundle build`, but watches your source files and rebuilds on any
     -i, --entry      Entry module(s)
     -o, --output     Directory to place build files into
     -f, --format     Only build specified formats  (default es,cjs,umd)
-    -w, --watch      Rebuilds on any change  (default false)
+    -w, --watch      Rebuilds on any change
     --target         Specify your target environment  (default node)
     --external       Specify external dependencies, or 'none'
-    --compress       Compress output using UglifyJS  (default true)
+    --compress       Compress output using UglifyJS
     --strict         Enforce undefined global context and add "use strict"
     --name           Specify name exposed in UMD builds
     --cwd            Use an alternative working directory  (default .)
-    --sourcemap      Generate source map  (default true)
+    --sourcemap      Generate source map
     -h, --help       Displays this message
 ```
+
 ### Specifying builds in `package.json`
 
 You can specify output builds in a `package.json` as follows:
@@ -95,7 +105,6 @@ Here's what's coming up for Microbundle:
 - [x] [TypeScript support](https://github.com/developit/microbundle/issues/5)
 - [x] [Flowtype support](https://github.com/developit/microbundle/issues/5#issuecomment-351075881)
 
-
 ## 🔨 Built with Microbundle
 
 - [Stockroom](https://github.com/developit/stockroom) Offload your store management to a worker easily.
@@ -106,7 +115,6 @@ Here's what's coming up for Microbundle:
 
 [MIT](https://oss.ninja/mit/developit/)
 
-
-[Rollup]: https://github.com/rollup/rollup
-[Bublé]: https://github.com/Rich-Harris/buble
-[Nodent]: https://github.com/MatAtBread/nodent-compiler
+[rollup]: https://github.com/rollup/rollup
+[bublé]: https://github.com/Rich-Harris/buble
+[nodent]: https://github.com/MatAtBread/nodent-compiler

--- a/src/index.js
+++ b/src/index.js
@@ -437,7 +437,7 @@ function createConfig(options, entry, format, writeMeta) {
 			legacy: true,
 			freeze: false,
 			esModule: false,
-			sourcemap: options.sourcemap !== false,
+			sourcemap: !!options.sourcemap,
 			treeshake: {
 				propertyReadSideEffects: false,
 			},

--- a/src/index.js
+++ b/src/index.js
@@ -319,7 +319,7 @@ function createConfig(options, entry, format, writeMeta) {
 					postcss({
 						plugins: [
 							autoprefixer(),
-							options.compress !== false &&
+							options.compress &&
 								cssnano({
 									preset: 'default',
 								}),
@@ -381,7 +381,7 @@ function createConfig(options, entry, format, writeMeta) {
 					// 	[`export default ${rollupName};`]: '',
 					// 	[`var ${rollupName} =`]: 'export default'
 					// }),
-					options.compress !== false && [
+					options.compress && [
 						uglify({
 							sourceMap: true,
 							output: { comments: false },

--- a/src/prog.js
+++ b/src/prog.js
@@ -24,7 +24,7 @@ export default handler => {
 		.option('--strict', 'Enforce undefined global context and add "use strict"')
 		.option('--name', 'Specify name exposed in UMD builds')
 		.option('--cwd', 'Use an alternative working directory', '.')
-		.option('--sourcemap', 'Generate source map', true);
+		.option('--sourcemap', 'Generate source map');
 
 	prog
 		.command('build [...entries]', '', { default: true })

--- a/src/prog.js
+++ b/src/prog.js
@@ -17,7 +17,7 @@ export default handler => {
 		.option('--entry, -i', 'Entry module(s)')
 		.option('--output, -o', 'Directory to place build files into')
 		.option('--format, -f', 'Only build specified formats', 'es,cjs,umd')
-		.option('--watch, -w', 'Rebuilds on any change', false)
+		.option('--watch, -w', 'Rebuilds on any change')
 		.option('--target', 'Specify your target environment', 'node')
 		.option('--external', `Specify external dependencies, or 'none'`)
 		.option('--compress', 'Compress output using UglifyJS')

--- a/src/prog.js
+++ b/src/prog.js
@@ -20,7 +20,7 @@ export default handler => {
 		.option('--watch, -w', 'Rebuilds on any change', false)
 		.option('--target', 'Specify your target environment', 'node')
 		.option('--external', `Specify external dependencies, or 'none'`)
-		.option('--compress', 'Compress output using UglifyJS', true)
+		.option('--compress', 'Compress output using UglifyJS')
 		.option('--strict', 'Enforce undefined global context and add "use strict"')
 		.option('--name', 'Specify name exposed in UMD builds')
 		.option('--cwd', 'Use an alternative working directory', '.')

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -8,11 +8,8 @@ Directory tree:
 basic
   dist
     basic-lib.js
-    basic-lib.js.map
     basic-lib.mjs
-    basic-lib.mjs.map
     basic-lib.umd.js
-    basic-lib.umd.js.map
   package.json
   src
     index.js
@@ -20,12 +17,12 @@ basic
 
 
 Build \\"basicLib\\" to dist:
-211 B: basic-lib.js.gz
-154 B: basic-lib.js.br
-211 B: basic-lib.mjs.gz
-155 B: basic-lib.mjs.br
-292 B: basic-lib.umd.js.gz
-228 B: basic-lib.umd.js.br"
+304 B: basic-lib.js.gz
+245 B: basic-lib.js.br
+966 B: basic-lib.mjs.gz
+888 B: basic-lib.mjs.br
+1.08 kB: basic-lib.umd.js.gz
+980 B: basic-lib.umd.js.br"
 `;
 
 exports[`fixtures basic-css 1`] = `
@@ -37,11 +34,8 @@ basic-css
   dist
     basic-css.css
     basic-css.js
-    basic-css.js.map
     basic-css.mjs
-    basic-css.mjs.map
     basic-css.umd.js
-    basic-css.umd.js.map
   package.json
   src
     index.js
@@ -49,12 +43,12 @@ basic-css
 
 
 Build \\"basicCss\\" to dist:
-107 B: basic-css.js.gz
-60 B: basic-css.js.br
-107 B: basic-css.mjs.gz
-61 B: basic-css.mjs.br
-188 B: basic-css.umd.js.gz
-135 B: basic-css.umd.js.br"
+130 B: basic-css.js.gz
+86 B: basic-css.js.br
+639 B: basic-css.mjs.gz
+588 B: basic-css.mjs.br
+760 B: basic-css.umd.js.gz
+680 B: basic-css.umd.js.br"
 `;
 
 exports[`fixtures basic-ts 1`] = `
@@ -65,11 +59,8 @@ Directory tree:
 basic-ts
   dist
     basic-lib-ts.js
-    basic-lib-ts.js.map
     basic-lib-ts.mjs
-    basic-lib-ts.mjs.map
     basic-lib-ts.umd.js
-    basic-lib-ts.umd.js.map
     car.d.ts
     index.d.ts
   package.json
@@ -80,12 +71,12 @@ basic-ts
 
 
 Build \\"basicLibTs\\" to dist:
-104 B: basic-lib-ts.js.gz
-76 B: basic-lib-ts.js.br
-97 B: basic-lib-ts.mjs.gz
-73 B: basic-lib-ts.mjs.br
-180 B: basic-lib-ts.umd.js.gz
-137 B: basic-lib-ts.umd.js.br"
+148 B: basic-lib-ts.js.gz
+104 B: basic-lib-ts.js.br
+780 B: basic-lib-ts.mjs.gz
+709 B: basic-lib-ts.mjs.br
+895 B: basic-lib-ts.umd.js.gz
+817 B: basic-lib-ts.umd.js.br"
 `;
 
 exports[`fixtures basic-tsx 1`] = `
@@ -96,11 +87,8 @@ Directory tree:
 basic-tsx
   dist
     basic-lib-tsx.js
-    basic-lib-tsx.js.map
     basic-lib-tsx.mjs
-    basic-lib-tsx.mjs.map
     basic-lib-tsx.umd.js
-    basic-lib-tsx.umd.js.map
     index.d.ts
   package.json
   src
@@ -109,12 +97,37 @@ basic-tsx
 
 
 Build \\"basicLibTsx\\" to dist:
-221 B: basic-lib-tsx.js.gz
-179 B: basic-lib-tsx.js.br
-221 B: basic-lib-tsx.mjs.gz
-193 B: basic-lib-tsx.mjs.br
-295 B: basic-lib-tsx.umd.js.gz
-236 B: basic-lib-tsx.umd.js.br"
+286 B: basic-lib-tsx.js.gz
+241 B: basic-lib-tsx.js.br
+1.18 kB: basic-lib-tsx.mjs.gz
+1.12 kB: basic-lib-tsx.mjs.br
+1.3 kB: basic-lib-tsx.umd.js.gz
+1.2 kB: basic-lib-tsx.umd.js.br"
+`;
+
+exports[`fixtures basic-with-compress 1`] = `
+"Used script: microbundle --compress
+
+Directory tree:
+
+basic-with-compress
+  dist
+    basic-with-compress.js
+    basic-with-compress.mjs
+    basic-with-compress.umd.js
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"basicWithCompress\\" to dist:
+211 B: basic-with-compress.js.gz
+154 B: basic-with-compress.js.br
+211 B: basic-with-compress.mjs.gz
+155 B: basic-with-compress.mjs.br
+298 B: basic-with-compress.umd.js.gz
+233 B: basic-with-compress.umd.js.br"
 `;
 
 exports[`fixtures basic-with-cwd 1`] = `
@@ -126,11 +139,8 @@ basic-with-cwd
   basic
     dist
       basic.js
-      basic.js.map
       basic.mjs
-      basic.mjs.map
       basic.umd.js
-      basic.umd.js.map
     package.json
     src
       index.js
@@ -139,12 +149,40 @@ basic-with-cwd
 
 
 Build \\"basic\\" to dist:
-211 B: basic.js.gz
-154 B: basic.js.br
-211 B: basic.mjs.gz
-155 B: basic.mjs.br
-287 B: basic.umd.js.gz
-224 B: basic.umd.js.br"
+304 B: basic.js.gz
+245 B: basic.js.br
+966 B: basic.mjs.gz
+888 B: basic.mjs.br
+1.08 kB: basic.umd.js.gz
+977 B: basic.umd.js.br"
+`;
+
+exports[`fixtures basic-with-sourcemap 1`] = `
+"Used script: microbundle --sourcemap
+
+Directory tree:
+
+basic-with-sourcemap
+  dist
+    basic-with-sourcemap.js
+    basic-with-sourcemap.js.map
+    basic-with-sourcemap.mjs
+    basic-with-sourcemap.mjs.map
+    basic-with-sourcemap.umd.js
+    basic-with-sourcemap.umd.js.map
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"basicWithSourcemap\\" to dist:
+304 B: basic-with-sourcemap.js.gz
+245 B: basic-with-sourcemap.js.br
+966 B: basic-with-sourcemap.mjs.gz
+888 B: basic-with-sourcemap.mjs.br
+1.09 kB: basic-with-sourcemap.umd.js.gz
+983 B: basic-with-sourcemap.umd.js.br"
 `;
 
 exports[`fixtures custom-source 1`] = `
@@ -155,11 +193,8 @@ Directory tree:
 custom-source
   dist
     custom-source.js
-    custom-source.js.map
     custom-source.mjs
-    custom-source.mjs.map
     custom-source.umd.js
-    custom-source.umd.js.map
   package.json
   src
     custom-source.js
@@ -167,12 +202,12 @@ custom-source
 
 
 Build \\"customSource\\" to dist:
-211 B: custom-source.js.gz
-154 B: custom-source.js.br
-211 B: custom-source.mjs.gz
-155 B: custom-source.mjs.br
-293 B: custom-source.umd.js.gz
-226 B: custom-source.umd.js.br"
+311 B: custom-source.js.gz
+249 B: custom-source.js.br
+974 B: custom-source.mjs.gz
+894 B: custom-source.mjs.br
+1.09 kB: custom-source.umd.js.gz
+982 B: custom-source.umd.js.br"
 `;
 
 exports[`fixtures custom-source-with-cwd 1`] = `
@@ -184,11 +219,8 @@ custom-source-with-cwd
   custom-source
     dist
       custom-src.js
-      custom-src.js.map
       custom-src.mjs
-      custom-src.mjs.map
       custom-src.umd.js
-      custom-src.umd.js.map
     package.json
     src
       custom-source.js
@@ -197,12 +229,12 @@ custom-source-with-cwd
 
 
 Build \\"customSrc\\" to dist:
-211 B: custom-src.js.gz
-154 B: custom-src.js.br
-211 B: custom-src.mjs.gz
-155 B: custom-src.mjs.br
-291 B: custom-src.umd.js.gz
-228 B: custom-src.umd.js.br"
+311 B: custom-src.js.gz
+249 B: custom-src.js.br
+974 B: custom-src.mjs.gz
+894 B: custom-src.mjs.br
+1.09 kB: custom-src.umd.js.gz
+981 B: custom-src.umd.js.br"
 `;
 
 exports[`fixtures jsx 1`] = `
@@ -213,22 +245,19 @@ Directory tree:
 jsx
   dist
     jsx.js
-    jsx.js.map
     jsx.mjs
-    jsx.mjs.map
     jsx.umd.js
-    jsx.umd.js.map
   index.js
   package.json
 
 
 Build \\"jsx\\" to dist:
-211 B: jsx.js.gz
-168 B: jsx.js.br
-212 B: jsx.mjs.gz
-170 B: jsx.mjs.br
-283 B: jsx.umd.js.gz
-230 B: jsx.umd.js.br"
+289 B: jsx.js.gz
+245 B: jsx.js.br
+817 B: jsx.mjs.gz
+748 B: jsx.mjs.br
+927 B: jsx.umd.js.gz
+837 B: jsx.umd.js.br"
 `;
 
 exports[`fixtures name-custom-amd 1`] = `
@@ -239,11 +268,8 @@ Directory tree:
 name-custom-amd
   dist
     name-custom-amd.js
-    name-custom-amd.js.map
     name-custom-amd.mjs
-    name-custom-amd.mjs.map
     name-custom-amd.umd.js
-    name-custom-amd.umd.js.map
   package.json
   src
     index.js
@@ -251,12 +277,12 @@ name-custom-amd
 
 
 Build \\"customNameAmd\\" to dist:
-211 B: name-custom-amd.js.gz
-154 B: name-custom-amd.js.br
-211 B: name-custom-amd.mjs.gz
-155 B: name-custom-amd.mjs.br
-295 B: name-custom-amd.umd.js.gz
-230 B: name-custom-amd.umd.js.br"
+304 B: name-custom-amd.js.gz
+245 B: name-custom-amd.js.br
+966 B: name-custom-amd.mjs.gz
+888 B: name-custom-amd.mjs.br
+1.09 kB: name-custom-amd.umd.js.gz
+980 B: name-custom-amd.umd.js.br"
 `;
 
 exports[`fixtures name-custom-cli 1`] = `
@@ -267,11 +293,8 @@ Directory tree:
 name-custom-cli
   dist
     name-custom.js
-    name-custom.js.map
     name-custom.mjs
-    name-custom.mjs.map
     name-custom.umd.js
-    name-custom.umd.js.map
   package.json
   src
     index.js
@@ -279,12 +302,12 @@ name-custom-cli
 
 
 Build \\"nameCustomCli\\" to dist:
-211 B: name-custom.js.gz
-154 B: name-custom.js.br
-211 B: name-custom.mjs.gz
-155 B: name-custom.mjs.br
-294 B: name-custom.umd.js.gz
-231 B: name-custom.umd.js.br"
+304 B: name-custom.js.gz
+245 B: name-custom.js.br
+966 B: name-custom.mjs.gz
+888 B: name-custom.mjs.br
+1.08 kB: name-custom.umd.js.gz
+990 B: name-custom.umd.js.br"
 `;
 
 exports[`fixtures no-pkg 1`] = `
@@ -295,23 +318,20 @@ Directory tree:
 no-pkg
   dist
     no-pkg.js
-    no-pkg.js.map
     no-pkg.mjs
-    no-pkg.mjs.map
     no-pkg.umd.js
-    no-pkg.umd.js.map
   src
     index.js
     two.js
 
 
 Build \\"noPkg\\" to dist:
-211 B: no-pkg.js.gz
-154 B: no-pkg.js.br
-211 B: no-pkg.mjs.gz
-155 B: no-pkg.mjs.br
-288 B: no-pkg.umd.js.gz
-228 B: no-pkg.umd.js.br"
+304 B: no-pkg.js.gz
+245 B: no-pkg.js.br
+966 B: no-pkg.mjs.gz
+888 B: no-pkg.mjs.br
+1.08 kB: no-pkg.umd.js.gz
+978 B: no-pkg.umd.js.br"
 `;
 
 exports[`fixtures no-pkg-name 1`] = `
@@ -322,11 +342,8 @@ Directory tree:
 no-pkg-name
   dist
     no-pkg-name.js
-    no-pkg-name.js.map
     no-pkg-name.mjs
-    no-pkg-name.mjs.map
     no-pkg-name.umd.js
-    no-pkg-name.umd.js.map
   package.json
   src
     index.js
@@ -334,10 +351,10 @@ no-pkg-name
 
 
 Build \\"noPkgName\\" to dist:
-211 B: no-pkg-name.js.gz
-154 B: no-pkg-name.js.br
-211 B: no-pkg-name.mjs.gz
-155 B: no-pkg-name.mjs.br
-292 B: no-pkg-name.umd.js.gz
-230 B: no-pkg-name.umd.js.br"
+304 B: no-pkg-name.js.gz
+245 B: no-pkg-name.js.br
+966 B: no-pkg-name.mjs.gz
+888 B: no-pkg-name.mjs.br
+1.08 kB: no-pkg-name.umd.js.gz
+981 B: no-pkg-name.umd.js.br"
 `;

--- a/test/fixtures/basic-with-compress/package.json
+++ b/test/fixtures/basic-with-compress/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "basic-with-compress",
+  "scripts": {
+    "build": "microbundle --compress"
+  }
+}

--- a/test/fixtures/basic-with-compress/src/index.js
+++ b/test/fixtures/basic-with-compress/src/index.js
@@ -1,0 +1,5 @@
+import { two } from './two';
+
+export default async function(...args) {
+	return [await two(...args), await two(...args)];
+}

--- a/test/fixtures/basic-with-compress/src/two.js
+++ b/test/fixtures/basic-with-compress/src/two.js
@@ -1,0 +1,3 @@
+export async function two(...args) {
+	return args.reduce((total, value) => total + value, 0);
+}

--- a/test/fixtures/basic-with-sourcemap/package.json
+++ b/test/fixtures/basic-with-sourcemap/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "basic-with-sourcemap",
+  "scripts": {
+    "build": "microbundle --sourcemap"
+  }
+}

--- a/test/fixtures/basic-with-sourcemap/src/index.js
+++ b/test/fixtures/basic-with-sourcemap/src/index.js
@@ -1,0 +1,5 @@
+import { two } from './two';
+
+export default async function(...args) {
+	return [await two(...args), await two(...args)];
+}

--- a/test/fixtures/basic-with-sourcemap/src/two.js
+++ b/test/fixtures/basic-with-sourcemap/src/two.js
@@ -1,0 +1,3 @@
+export async function two(...args) {
+	return args.reduce((total, value) => total + value, 0);
+}


### PR DESCRIPTION
Addresses comments in #66 and #73. Went ahead with a PR just so that we can see what it'd look/feel like in action.

**_TLDR:_**

* Only enable compression & sourcemaps when desired
* Seems like most rely upon the `--no-*` flags (myself included) which were undocumented anyway
* Update snapshots' file sizes
* Add two fixtures: `basic-with-compress`, `basic-with-sourcemap`
* Update README docs

---

_<sup><b>*</b></sup> Biased_