### PR TITLE
Fix incorrect default output filename (fixes #188)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ export default async function microbundle(options) {
 		.forEach(file => options.input.push(...file));
 
 	let main = resolve(cwd, options.output || options.pkg.main || 'dist');
-	if (!main.match(/\.[a-z]+$/) || (await isDir(main))) {
+	if (!main.match(/\.[a-z]+$/)) {
 		main = resolve(main, `${removeScope(options.pkg.name)}.js`);
 	}
 	options.output = main;

--- a/src/index.js
+++ b/src/index.js
@@ -111,9 +111,10 @@ export default async function microbundle(options) {
 		.map(file => glob(file))
 		.forEach(file => options.input.push(...file));
 
-	let main = resolve(cwd, options.output || options.pkg.main || 'dist');
+	const defaultMain = `dist/${removeScope(options.pkg.name)}.js`;
+	let main = resolve(cwd, options.output || options.pkg.main || defaultMain);
 	if (!main.match(/\.[a-z]+$/)) {
-		main = resolve(main, `${removeScope(options.pkg.name)}.js`);
+		main = resolve(main, 'index.js');
 	}
 	options.output = main;
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -147,6 +147,34 @@ Build \\"basic\\" to dist:
 224 B: basic.umd.js.br"
 `;
 
+exports[`fixtures basic-with-main-dir 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+basic-with-main-dir
+  dist
+    index.js
+    index.js.map
+    index.mjs
+    index.mjs.map
+    index.umd.js
+    index.umd.js.map
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"basicWithMainDir\\" to dist:
+211 B: index.js.gz
+154 B: index.js.br
+211 B: index.mjs.gz
+155 B: index.mjs.br
+298 B: index.umd.js.gz
+233 B: index.umd.js.br"
+`;
+
 exports[`fixtures custom-source 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/basic-with-main-dir/package.json
+++ b/test/fixtures/basic-with-main-dir/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "basic-with-main-dir",
+  "main": "dist"
+}

--- a/test/fixtures/basic-with-main-dir/src/index.js
+++ b/test/fixtures/basic-with-main-dir/src/index.js
@@ -1,0 +1,5 @@
+import { two } from './two';
+
+export default async function(...args) {
+	return [await two(...args), await two(...args)];
+}

--- a/test/fixtures/basic-with-main-dir/src/two.js
+++ b/test/fixtures/basic-with-main-dir/src/two.js
@@ -1,0 +1,3 @@
+export async function two(...args) {
+	return args.reduce((total, value) => total + value, 0);
+}


### PR DESCRIPTION
For example if `"main": "lib"` in `package.json` then the output file should be `lib/index.js` for Node module resolution.