### PR TITLE
Bugfix/ts named imports (fixes #193)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -285,8 +285,10 @@ function createConfig(options, entry, format, writeMeta) {
 	let nameCache = {};
 	let mangleOptions = options.pkg.mangle || false;
 
+	const useTypescript = extname(entry) === '.ts' || extname(entry) === '.tsx';
+
 	let exportType;
-	if (format !== 'es') {
+	if (!useTypescript && format !== 'es') {
 		try {
 			let file = fs.readFileSync(entry, 'utf-8');
 			let hasDefault = /\bexport\s*default\s*[a-zA-Z_$]/.test(file);
@@ -297,8 +299,6 @@ function createConfig(options, entry, format, writeMeta) {
 			if (hasDefault && hasNamed) exportType = 'default';
 		} catch (e) {}
 	}
-
-	const useTypescript = extname(entry) === '.ts' || extname(entry) === '.tsx';
 
 	const externalPredicate = new RegExp(`^(${external.join('|')})($|/)`);
 	const externalTest =

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -80,12 +80,12 @@ basic-ts
 
 
 Build \\"basicLibTs\\" to dist:
-104 B: basic-lib-ts.js.gz
-76 B: basic-lib-ts.js.br
-97 B: basic-lib-ts.mjs.gz
-73 B: basic-lib-ts.mjs.br
-180 B: basic-lib-ts.umd.js.gz
-137 B: basic-lib-ts.umd.js.br"
+121 B: basic-lib-ts.js.gz
+98 B: basic-lib-ts.js.br
+122 B: basic-lib-ts.mjs.gz
+103 B: basic-lib-ts.mjs.br
+208 B: basic-lib-ts.umd.js.gz
+169 B: basic-lib-ts.umd.js.br"
 `;
 
 exports[`fixtures basic-tsx 1`] = `

--- a/test/fixtures/basic-ts/src/index.ts
+++ b/test/fixtures/basic-ts/src/index.ts
@@ -1,5 +1,7 @@
 import Car from './car';
 
 let Ferrari = new Car();
+let Pinto = new Car();
 
 export default Ferrari;
+export { Pinto };


### PR DESCRIPTION
Fixes really confusing crash using named exports in TypeScript. See issue in title. It's linked to @developit's optimization in 8960114faf8758366cc602d7aa6e2e7c048f0775. I don't like my fix.

- Might it also crash using non-Node features like Flow types?
- Would this be better as a Rollup plugin after transpile that changes the input file?
- The regexes (L296) could be combined
    ```regex
    // before:  /\bexport\s*   (let|const|var|async|function\*?)\s*[a-zA-Z_$*] /
    // after:   /\bexport\s+({|(let|const|var|async|function\*?)\s+[a-zA-Z_$*])/
    // format:  
    const regex = (...args) => new RegExp(String.raw(...args).replace(/\s+/g, ''))

    regex`
      \bexport\s+
      ( {
      | ( let
        | const
        | var
        | async
        | function\*?
        )
        \s+[a-zA-Z_$*]
      )
    `
    ```