### PR TITLE
Bugfix/ts entry dir (fixes #196)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -286,8 +286,10 @@ function createConfig(options, entry, format, writeMeta) {
 	let nameCache = {};
 	let mangleOptions = options.pkg.mangle || false;
 
+	const useTypescript = extname(entry) === '.ts' || extname(entry) === '.tsx';
+
 	let exportType;
-	if (format !== 'es') {
+	if (!useTypescript && format !== 'es') {
 		try {
 			let file = fs.readFileSync(entry, 'utf-8');
 			let hasDefault = /\bexport\s*default\s*[a-zA-Z_$]/.test(file);
@@ -298,8 +300,6 @@ function createConfig(options, entry, format, writeMeta) {
 			if (hasDefault && hasNamed) exportType = 'default';
 		} catch (e) {}
 	}
-
-	const useTypescript = extname(entry) === '.ts' || extname(entry) === '.tsx';
 
 	const externalPredicate = new RegExp(`^(${external.join('|')})($|/)`);
 	const externalTest =

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ export default async function microbundle(options) {
 		.forEach(file => options.input.push(...file));
 
 	let main = resolve(cwd, options.output || options.pkg.main || 'dist');
-	if (!main.match(/\.[a-z]+$/) || (await isDir(main))) {
+	if (!main.match(/\.[a-z]+$/)) {
 		main = resolve(main, `${removeScope(options.pkg.name)}.js`);
 	}
 	options.output = main;

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ export default async function microbundle(options) {
 	let entries = (await map([].concat(options.input), async file => {
 		file = resolve(cwd, file);
 		if (await isDir(file)) {
-			file = resolve(file, 'index.js');
+			file = await jsOrTs(`${file}/index`);
 		}
 		return file;
 	})).filter((item, i, arr) => arr.indexOf(item) === i);

--- a/src/index.js
+++ b/src/index.js
@@ -111,9 +111,10 @@ export default async function microbundle(options) {
 		.map(file => glob(file))
 		.forEach(file => options.input.push(...file));
 
-	let main = resolve(cwd, options.output || options.pkg.main || 'dist');
+	const defaultMain = `dist/${removeScope(options.pkg.name)}.js`;
+	let main = resolve(cwd, options.output || options.pkg.main || defaultMain);
 	if (!main.match(/\.[a-z]+$/)) {
-		main = resolve(main, `${removeScope(options.pkg.name)}.js`);
+		main = resolve(main, 'index.js');
 	}
 	options.output = main;
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -147,6 +147,34 @@ Build \\"basic\\" to dist:
 224 B: basic.umd.js.br"
 `;
 
+exports[`fixtures basic-with-main-dir 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+basic-with-main-dir
+  dist
+    index.js
+    index.js.map
+    index.mjs
+    index.mjs.map
+    index.umd.js
+    index.umd.js.map
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"basicWithMainDir\\" to dist:
+211 B: index.js.gz
+154 B: index.js.br
+211 B: index.mjs.gz
+155 B: index.mjs.br
+298 B: index.umd.js.gz
+233 B: index.umd.js.br"
+`;
+
 exports[`fixtures custom-source 1`] = `
 "Used script: microbundle
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -80,12 +80,12 @@ basic-ts
 
 
 Build \\"basicLibTs\\" to dist:
-104 B: basic-lib-ts.js.gz
-76 B: basic-lib-ts.js.br
-97 B: basic-lib-ts.mjs.gz
-73 B: basic-lib-ts.mjs.br
-180 B: basic-lib-ts.umd.js.gz
-137 B: basic-lib-ts.umd.js.br"
+121 B: basic-lib-ts.js.gz
+98 B: basic-lib-ts.js.br
+122 B: basic-lib-ts.mjs.gz
+103 B: basic-lib-ts.mjs.br
+208 B: basic-lib-ts.umd.js.gz
+169 B: basic-lib-ts.umd.js.br"
 `;
 
 exports[`fixtures basic-tsx 1`] = `

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -88,6 +88,37 @@ Build \\"basicLibTs\\" to dist:
 169 B: basic-lib-ts.umd.js.br"
 `;
 
+exports[`fixtures basic-ts-with-entry-dir 1`] = `
+"Used script: microbundle src
+
+Directory tree:
+
+basic-ts-with-entry-dir
+  dist
+    basic-ts-with-entry-dir.js
+    basic-ts-with-entry-dir.js.map
+    basic-ts-with-entry-dir.mjs
+    basic-ts-with-entry-dir.mjs.map
+    basic-ts-with-entry-dir.umd.js
+    basic-ts-with-entry-dir.umd.js.map
+    car.d.ts
+    index.d.ts
+  package.json
+  src
+    car.ts
+    index.ts
+  tsconfig.json
+
+
+Build \\"basicTsWithEntryDir\\" to dist:
+121 B: basic-ts-with-entry-dir.js.gz
+98 B: basic-ts-with-entry-dir.js.br
+122 B: basic-ts-with-entry-dir.mjs.gz
+103 B: basic-ts-with-entry-dir.mjs.br
+217 B: basic-ts-with-entry-dir.umd.js.gz
+175 B: basic-ts-with-entry-dir.umd.js.br"
+`;
+
 exports[`fixtures basic-ts-with-main-dir 1`] = `
 "Used script: microbundle
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -209,6 +209,34 @@ Build \\"basic\\" to dist:
 224 B: basic.umd.js.br"
 `;
 
+exports[`fixtures basic-with-entry-dir 1`] = `
+"Used script: microbundle src
+
+Directory tree:
+
+basic-with-entry-dir
+  dist
+    basic-with-entry-dir.js
+    basic-with-entry-dir.js.map
+    basic-with-entry-dir.mjs
+    basic-with-entry-dir.mjs.map
+    basic-with-entry-dir.umd.js
+    basic-with-entry-dir.umd.js.map
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"basicWithEntryDir\\" to dist:
+211 B: basic-with-entry-dir.js.gz
+154 B: basic-with-entry-dir.js.br
+211 B: basic-with-entry-dir.mjs.gz
+155 B: basic-with-entry-dir.mjs.br
+299 B: basic-with-entry-dir.umd.js.gz
+233 B: basic-with-entry-dir.umd.js.br"
+`;
+
 exports[`fixtures basic-with-main-dir 1`] = `
 "Used script: microbundle
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -88,6 +88,37 @@ Build \\"basicLibTs\\" to dist:
 169 B: basic-lib-ts.umd.js.br"
 `;
 
+exports[`fixtures basic-ts-with-main-dir 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+basic-ts-with-main-dir
+  dist
+    car.d.ts
+    index.d.ts
+    index.js
+    index.js.map
+    index.mjs
+    index.mjs.map
+    index.umd.js
+    index.umd.js.map
+  package.json
+  src
+    car.ts
+    index.ts
+  tsconfig.json
+
+
+Build \\"basicTsWithMainDir\\" to dist:
+121 B: index.js.gz
+98 B: index.js.br
+122 B: index.mjs.gz
+103 B: index.mjs.br
+217 B: index.umd.js.gz
+181 B: index.umd.js.br"
+`;
+
 exports[`fixtures basic-tsx 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/basic-ts-with-entry-dir/package.json
+++ b/test/fixtures/basic-ts-with-entry-dir/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "basic-ts-with-entry-dir",
+	"scripts": {
+		"build": "microbundle src"
+	}
+}

--- a/test/fixtures/basic-ts-with-entry-dir/src/car.ts
+++ b/test/fixtures/basic-ts-with-entry-dir/src/car.ts
@@ -1,0 +1,9 @@
+export interface Driveable {
+	drive(distance: number): boolean;
+}
+
+export default class Car implements Driveable {
+	public drive(distance: number): boolean {
+		return true;
+	}
+}

--- a/test/fixtures/basic-ts-with-entry-dir/src/index.ts
+++ b/test/fixtures/basic-ts-with-entry-dir/src/index.ts
@@ -1,0 +1,7 @@
+import Car from './car';
+
+let Ferrari = new Car();
+let Pinto = new Car();
+
+export default Ferrari;
+export { Pinto };

--- a/test/fixtures/basic-ts-with-entry-dir/tsconfig.json
+++ b/test/fixtures/basic-ts-with-entry-dir/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"rootDir": "./src"
+	}
+}

--- a/test/fixtures/basic-ts-with-main-dir/package.json
+++ b/test/fixtures/basic-ts-with-main-dir/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "basic-ts-with-main-dir",
+  "main": "dist"
+}

--- a/test/fixtures/basic-ts-with-main-dir/src/car.ts
+++ b/test/fixtures/basic-ts-with-main-dir/src/car.ts
@@ -1,0 +1,9 @@
+export interface Driveable {
+	drive(distance: number): boolean;
+}
+
+export default class Car implements Driveable {
+	public drive(distance: number): boolean {
+		return true;
+	}
+}

--- a/test/fixtures/basic-ts-with-main-dir/src/index.ts
+++ b/test/fixtures/basic-ts-with-main-dir/src/index.ts
@@ -1,0 +1,7 @@
+import Car from './car';
+
+let Ferrari = new Car();
+let Pinto = new Car();
+
+export default Ferrari;
+export { Pinto };

--- a/test/fixtures/basic-ts-with-main-dir/tsconfig.json
+++ b/test/fixtures/basic-ts-with-main-dir/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"rootDir": "./src"
+	}
+}

--- a/test/fixtures/basic-ts/src/index.ts
+++ b/test/fixtures/basic-ts/src/index.ts
@@ -1,5 +1,7 @@
 import Car from './car';
 
 let Ferrari = new Car();
+let Pinto = new Car();
 
 export default Ferrari;
+export { Pinto };

--- a/test/fixtures/basic-with-entry-dir/package.json
+++ b/test/fixtures/basic-with-entry-dir/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "basic-with-entry-dir",
+	"scripts": {
+		"build": "microbundle src"
+	}
+}

--- a/test/fixtures/basic-with-entry-dir/src/index.js
+++ b/test/fixtures/basic-with-entry-dir/src/index.js
@@ -1,0 +1,5 @@
+import { two } from './two';
+
+export default async function(...args) {
+	return [await two(...args), await two(...args)];
+}

--- a/test/fixtures/basic-with-entry-dir/src/two.js
+++ b/test/fixtures/basic-with-entry-dir/src/two.js
@@ -1,0 +1,3 @@
+export async function two(...args) {
+	return args.reduce((total, value) => total + value, 0);
+}

--- a/test/fixtures/basic-with-main-dir/package.json
+++ b/test/fixtures/basic-with-main-dir/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "basic-with-main-dir",
+  "main": "dist"
+}

--- a/test/fixtures/basic-with-main-dir/src/index.js
+++ b/test/fixtures/basic-with-main-dir/src/index.js
@@ -1,0 +1,5 @@
+import { two } from './two';
+
+export default async function(...args) {
+	return [await two(...args), await two(...args)];
+}

--- a/test/fixtures/basic-with-main-dir/src/two.js
+++ b/test/fixtures/basic-with-main-dir/src/two.js
@@ -1,0 +1,3 @@
+export async function two(...args) {
+	return args.reduce((total, value) => total + value, 0);
+}


### PR DESCRIPTION
Calls `jsOrTs`...again. The entire block arguably belongs a few lines up and the TS checks are beginning to smell. The Reason PR will be better for refactoring though.

More tests that depend on #190 and #194 because it was easier. I can rebase if necessary.

The actual diff is https://github.com/texastoland/microbundle/compare/7ca814a044adbacb7497367ff9228e11642abc5a...bugfix/ts-entry-dir.