### PR TITLE
change rollup-plugin-uglify@3.x to rollup-plugin-terser. fixes #201.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rollup-plugin-sizes": "^0.4.2",
     "rollup-plugin-strict-alias": "^1.0.0",
     "rollup-plugin-typescript2": "^0.13.0",
-    "rollup-plugin-uglify": "^3.0.0",
+    "rollup-plugin-terser": "^1.0.0",
     "sade": "^1.4.0",
     "tiny-glob": "^0.2.0",
     "tslib": "^1.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import nodent from 'rollup-plugin-nodent';
 import commonjs from 'rollup-plugin-commonjs';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import buble from 'rollup-plugin-buble';
-import uglify from 'rollup-plugin-uglify';
+import { terser as uglify } from 'rollup-plugin-terser';
 import postcss from 'rollup-plugin-postcss';
 import alias from 'rollup-plugin-strict-alias';
 import gzipSize from 'gzip-size';

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -22,7 +22,7 @@ basic
 Build \\"basicLib\\" to dist:
 211 B: basic-lib.js.gz
 154 B: basic-lib.js.br
-211 B: basic-lib.mjs.gz
+210 B: basic-lib.mjs.gz
 155 B: basic-lib.mjs.br
 292 B: basic-lib.umd.js.gz
 228 B: basic-lib.umd.js.br"
@@ -51,8 +51,8 @@ basic-css
 Build \\"basicCss\\" to dist:
 107 B: basic-css.js.gz
 60 B: basic-css.js.br
-107 B: basic-css.mjs.gz
-61 B: basic-css.mjs.br
+106 B: basic-css.mjs.gz
+56 B: basic-css.mjs.br
 188 B: basic-css.umd.js.gz
 135 B: basic-css.umd.js.br"
 `;
@@ -111,8 +111,8 @@ basic-tsx
 Build \\"basicLibTsx\\" to dist:
 221 B: basic-lib-tsx.js.gz
 179 B: basic-lib-tsx.js.br
-221 B: basic-lib-tsx.mjs.gz
-193 B: basic-lib-tsx.mjs.br
+222 B: basic-lib-tsx.mjs.gz
+197 B: basic-lib-tsx.mjs.br
 295 B: basic-lib-tsx.umd.js.gz
 236 B: basic-lib-tsx.umd.js.br"
 `;
@@ -141,7 +141,7 @@ basic-with-cwd
 Build \\"basic\\" to dist:
 211 B: basic.js.gz
 154 B: basic.js.br
-211 B: basic.mjs.gz
+210 B: basic.mjs.gz
 155 B: basic.mjs.br
 287 B: basic.umd.js.gz
 224 B: basic.umd.js.br"
@@ -169,7 +169,7 @@ custom-source
 Build \\"customSource\\" to dist:
 211 B: custom-source.js.gz
 154 B: custom-source.js.br
-211 B: custom-source.mjs.gz
+210 B: custom-source.mjs.gz
 155 B: custom-source.mjs.br
 293 B: custom-source.umd.js.gz
 226 B: custom-source.umd.js.br"
@@ -199,7 +199,7 @@ custom-source-with-cwd
 Build \\"customSrc\\" to dist:
 211 B: custom-src.js.gz
 154 B: custom-src.js.br
-211 B: custom-src.mjs.gz
+210 B: custom-src.mjs.gz
 155 B: custom-src.mjs.br
 291 B: custom-src.umd.js.gz
 228 B: custom-src.umd.js.br"
@@ -253,7 +253,7 @@ name-custom-amd
 Build \\"customNameAmd\\" to dist:
 211 B: name-custom-amd.js.gz
 154 B: name-custom-amd.js.br
-211 B: name-custom-amd.mjs.gz
+210 B: name-custom-amd.mjs.gz
 155 B: name-custom-amd.mjs.br
 295 B: name-custom-amd.umd.js.gz
 230 B: name-custom-amd.umd.js.br"
@@ -281,7 +281,7 @@ name-custom-cli
 Build \\"nameCustomCli\\" to dist:
 211 B: name-custom.js.gz
 154 B: name-custom.js.br
-211 B: name-custom.mjs.gz
+210 B: name-custom.mjs.gz
 155 B: name-custom.mjs.br
 294 B: name-custom.umd.js.gz
 231 B: name-custom.umd.js.br"
@@ -308,7 +308,7 @@ no-pkg
 Build \\"noPkg\\" to dist:
 211 B: no-pkg.js.gz
 154 B: no-pkg.js.br
-211 B: no-pkg.mjs.gz
+210 B: no-pkg.mjs.gz
 155 B: no-pkg.mjs.br
 288 B: no-pkg.umd.js.gz
 228 B: no-pkg.umd.js.br"
@@ -336,7 +336,7 @@ no-pkg-name
 Build \\"noPkgName\\" to dist:
 211 B: no-pkg-name.js.gz
 154 B: no-pkg-name.js.br
-211 B: no-pkg-name.mjs.gz
+210 B: no-pkg-name.mjs.gz
 155 B: no-pkg-name.mjs.br
 292 B: no-pkg-name.umd.js.gz
 230 B: no-pkg-name.umd.js.br"


### PR DESCRIPTION
The compressor that `rollup-plugin-uglify` was using (`uglify-es`) produced broken code under certain circumstances where `toplevel: true`. You can see an example here: #201

First I tried upgrading to `rollup-plugin-uglify@4.x`, but it looks like they removed `uglify-es`, so now it only compiles ES5 compliant code. 

Following the instructions here, https://github.com/TrySound/rollup-plugin-uglify#rollup-plugin-uglify-, I tried swapping uglify for `rollup-plugin-terser`.

That swap seemmed to fix this syntax error in #201.

---

**Side note:** we should probably be testing the actual outputs rather than the file size changes. I did check to make sure that the outputs were reasonable, but the tests should probably ensure outputs work.