### PR TITLE
fix(typescript): add cache folder for each build format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -342,6 +342,7 @@ function createConfig(options, entry, format, writeMeta) {
 					useTypescript &&
 						typescript({
 							typescript: require('typescript'),
+							cacheRoot: `./.rts2_cache_${format}`,
 							tsconfigDefaults: {
 								compilerOptions: { declaration: true, jsx: options.jsx },
 							},


### PR DESCRIPTION
Solves #169.

Change event triggers multiple concurrent rebuilds. Error happens when multiple ts instances try to access cache files. 