### PR TITLE
feat(sourcemaps): support for ts sourcemaps and invert sourcemap flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,10 @@ export default async function microbundle(options) {
 	options.name =
 		options.name || options.pkg.amdName || safeVariableName(options.pkg.name);
 
+	if (options.sourcemap !== false) {
+		options.sourcemap = true;
+	}
+
 	const jsOrTs = async filename =>
 		resolve(
 			cwd,
@@ -345,7 +349,11 @@ function createConfig(options, entry, format, writeMeta) {
 							typescript: require('typescript'),
 							cacheRoot: `./.rts2_cache_${format}`,
 							tsconfigDefaults: {
-								compilerOptions: { declaration: true, jsx: options.jsx },
+								compilerOptions: {
+									sourceMap: options.sourcemap,
+									declaration: true,
+									jsx: options.jsx,
+								},
 							},
 						}),
 					!useTypescript && flow({ all: true, pretty: true }),
@@ -452,7 +460,7 @@ function createConfig(options, entry, format, writeMeta) {
 			legacy: true,
 			freeze: false,
 			esModule: false,
-			sourcemap: options.sourcemap !== false,
+			sourcemap: options.sourcemap,
 			treeshake: {
 				propertyReadSideEffects: false,
 			},

--- a/src/prog.js
+++ b/src/prog.js
@@ -26,7 +26,7 @@ export default handler => {
 		.option('--strict', 'Enforce undefined global context and add "use strict"')
 		.option('--name', 'Specify name exposed in UMD builds')
 		.option('--cwd', 'Use an alternative working directory', '.')
-		.option('--sourcemap', 'Generate source map', true)
+		.option('--no-sourcemap', "Don't generate source map")
 		.option('--raw', 'Show raw byte size', false)
 		.option(
 			'--jsx',

--- a/src/prog.js
+++ b/src/prog.js
@@ -26,7 +26,8 @@ export default handler => {
 		.option('--strict', 'Enforce undefined global context and add "use strict"')
 		.option('--name', 'Specify name exposed in UMD builds')
 		.option('--cwd', 'Use an alternative working directory', '.')
-		.option('--no-sourcemap', "Don't generate source map")
+		.option('--sourcemap', 'Generate source map', true)
+		.example("microbundle --no-sourcemap # don't generate sourcemaps")
 		.option('--raw', 'Show raw byte size', false)
 		.option(
 			'--jsx',


### PR DESCRIPTION
Closes  #216.

Keep in mind that this is a breaking change, since we changed name of the `sourcemap` flag. I played a bit with `sade`, we can keep `sourcemap` flag as it is and it would work with `--no-sourcemap` ( it would set `sourcemap` to false ), but I think this better communicates intentions - sourcemaps are generated by default, turn them off if you want.