### PR TITLE
Upgrades typescript plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rollup-plugin-sizes": "^0.4.2",
     "rollup-plugin-strict-alias": "^1.0.0",
     "rollup-plugin-terser": "^1.0.1",
-    "rollup-plugin-typescript2": "^0.13.0",
+    "rollup-plugin-typescript2": "^0.17.0",
     "sade": "^1.4.0",
     "tiny-glob": "^0.2.0",
     "tslib": "^1.9.0",


### PR DESCRIPTION
Specifically, I ran in to this: https://github.com/ezolenko/rollup-plugin-typescript2/issues/105 which is fixed in 0.17

Doesn't seem to have any breaking api changes, tests work fine