### PR TITLE
Add back shebang handling

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,21 +3,12 @@ module.exports = {
 		[
 			'@babel/preset-env',
 			{
-				exclude: [
-					'transform-async-to-generator',
-					'proposal-async-generator-functions',
-					'transform-regenerator',
-				],
 				loose: true,
 				targets: {
-					chrome: '58',
-					ie: '11',
+					node: 'current',
 				},
 			},
 		],
 	],
-	plugins: [
-		['babel-plugin-transform-async-to-promises', { inlineHelpers: true }],
-		'@babel/plugin-syntax-jsx',
-	],
+	plugins: ['@babel/plugin-syntax-jsx'],
 };

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "husky": "^1.1.2",
     "jest": "^23.6.0",
     "lint-staged": "^8.0.0",
-    "prettier": "^1.13.0",
+    "prettier": "^1.15.3",
     "regenerator-runtime": "^0.12.1",
     "rimraf": "^2.6.2",
     "shell-quote": "^1.6.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import microbundle from '.';
 import prog from './prog';
 import { stdout } from './utils';

--- a/src/index.js
+++ b/src/index.js
@@ -106,8 +106,8 @@ export default async function microbundle(options) {
 				(await isFile(resolve(cwd, filename + '.ts')))
 					? '.ts'
 					: (await isFile(resolve(cwd, filename + '.tsx')))
-					? '.tsx'
-					: '.js'
+						? '.tsx'
+						: '.js'
 			}`,
 		);
 
@@ -117,10 +117,9 @@ export default async function microbundle(options) {
 			options.entries && options.entries.length
 				? options.entries
 				: (options.pkg.source && resolve(cwd, options.pkg.source)) ||
-						((await isDir(resolve(cwd, 'src'))) &&
-							(await jsOrTs('src/index'))) ||
-						(await jsOrTs('index')) ||
-						options.pkg.module,
+				  ((await isDir(resolve(cwd, 'src'))) && (await jsOrTs('src/index'))) ||
+				  (await jsOrTs('index')) ||
+				  options.pkg.module,
 		)
 		.map(file => glob(file))
 		.forEach(file => options.input.push(...file));
@@ -377,12 +376,15 @@ function createConfig(options, entry, format, writeMeta) {
 						babelrc: false,
 						exclude: 'node_modules/**',
 						plugins: [
-							'@babel/plugin-syntax-jsx',
+							require.resolve('@babel/plugin-syntax-jsx'),
 							[
-								'babel-plugin-transform-async-to-promises',
+								require.resolve('babel-plugin-transform-async-to-promises'),
 								{ inlineHelpers: true, externalHelpers: true },
 							],
-							['@babel/plugin-proposal-class-properties', { loose: true }],
+							[
+								require.resolve('@babel/plugin-proposal-class-properties'),
+								{ loose: true },
+							],
 						],
 					}),
 					{

--- a/src/index.js
+++ b/src/index.js
@@ -106,8 +106,8 @@ export default async function microbundle(options) {
 				(await isFile(resolve(cwd, filename + '.ts')))
 					? '.ts'
 					: (await isFile(resolve(cwd, filename + '.tsx')))
-						? '.tsx'
-						: '.js'
+					? '.tsx'
+					: '.js'
 			}`,
 		);
 
@@ -117,9 +117,10 @@ export default async function microbundle(options) {
 			options.entries && options.entries.length
 				? options.entries
 				: (options.pkg.source && resolve(cwd, options.pkg.source)) ||
-				  ((await isDir(resolve(cwd, 'src'))) && (await jsOrTs('src/index'))) ||
-				  (await jsOrTs('index')) ||
-				  options.pkg.module,
+						((await isDir(resolve(cwd, 'src'))) &&
+							(await jsOrTs('src/index'))) ||
+						(await jsOrTs('index')) ||
+						options.pkg.module,
 		)
 		.map(file => glob(file))
 		.forEach(file => options.input.push(...file));

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -480,3 +480,30 @@ Build \\"raw\\" to dist:
 1493 B: raw.umd.js.gz
 1245 B: raw.umd.js.br"
 `;
+
+exports[`fixtures shebang 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+shebang
+  dist
+    shebang.js
+    shebang.js.map
+    shebang.mjs
+    shebang.mjs.map
+    shebang.umd.js
+    shebang.umd.js.map
+  package.json
+  src
+    index.js
+
+
+Build \\"shebang\\" to dist:
+85 B: shebang.js.gz
+62 B: shebang.js.br
+89 B: shebang.mjs.gz
+70 B: shebang.mjs.br
+177 B: shebang.umd.js.gz
+149 B: shebang.umd.js.br"
+`;

--- a/test/fixtures/shebang/package.json
+++ b/test/fixtures/shebang/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "shebang"
+}

--- a/test/fixtures/shebang/src/index.js
+++ b/test/fixtures/shebang/src/index.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+export function foo() {
+	return 'hello world';
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,4 +88,12 @@ describe('fixtures', () => {
 			).toMatchSnapshot();
 		});
 	});
+
+	it('should keep shebang', () => {
+		expect(
+			fs
+				.readFileSync(resolve(FIXTURES_DIR, 'shebang/dist/shebang.js'), 'utf8')
+				.startsWith('#!'),
+		).toEqual(true);
+	});
 });


### PR DESCRIPTION
This PR fixes a regression that was introduced with #252 . This is due to bublé not having the correct acorn options set and is made more difficult by the fact that they ship their own private acorn version.

Fixes #255 

/cc @ForsakenHarmony 