### PR TITLE
feat: add support for Babel macros

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@babel/preset-flow": "^7.0.0",
     "asyncro": "^3.0.0",
     "autoprefixer": "^9.6.0",
+    "babel-plugin-macros": "^2.4.2",
     "babel-plugin-transform-async-to-promises": "^0.8.12",
     "babel-plugin-transform-replace-expressions": "^0.2.0",
     "brotli-size": "^0.1.0",

--- a/src/lib/babel-custom.js
+++ b/src/lib/babel-custom.js
@@ -83,48 +83,36 @@ export default babelPlugin.custom(babelCore => {
 				].filter(Boolean),
 			);
 
-			let babelOptions = {
-				presets: [],
-				plugins: [],
-			};
-			if (config.hasFilesystemConfig()) {
-				babelOptions = config.options;
+			const babelOptions = config.options || {};
 
-				if (babelOptions.presets) {
-					babelOptions.presets = babelOptions.presets.map(preset => {
-						// When preset-env is configured we want to make sure we override some settings.
-						// We want to make sure microbundle is still fast & creates small bundles
-						if (preset.file.request === '@babel/preset-env') {
-							preset = createConfigItem(
-								[
-									preset.file.resolved,
-									merge(
-										{
-											loose: true,
-											targets: customOptions.targets,
-										},
-										preset.options,
-										{
-											modules: false,
-											exclude: merge(
-												[
-													'transform-async-to-generator',
-													'transform-regenerator',
-												],
-												preset.options.exclude || [],
-											),
-										},
-									),
-								],
-								{
-									type: `preset`,
-								},
-							);
-						}
+			const envIdx = (babelOptions.presets || []).findIndex(preset =>
+				preset.file.request.includes('@babel/preset-env'),
+			);
 
-						return preset;
-					});
-				}
+			if (envIdx !== -1) {
+				const preset = babelOptions.presets[envIdx];
+				babelOptions.presets[envIdx] = createConfigItem(
+					[
+						preset.file.resolved,
+						merge(
+							{
+								loose: true,
+								targets: customOptions.targets,
+							},
+							preset.options,
+							{
+								modules: false,
+								exclude: merge(
+									['transform-async-to-generator', 'transform-regenerator'],
+									preset.options.exclude || [],
+								),
+							},
+						),
+					],
+					{
+						type: `preset`,
+					},
+				);
 			} else {
 				babelOptions.presets = createConfigItems('preset', [
 					{

--- a/src/lib/babel-custom.js
+++ b/src/lib/babel-custom.js
@@ -77,6 +77,9 @@ export default babelPlugin.custom(babelCore => {
 						name: '@babel/plugin-transform-regenerator',
 						async: false,
 					},
+					{
+						name: 'babel-plugin-macros',
+					},
 				].filter(Boolean),
 			);
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1374,6 +1374,54 @@ return function(){function t(){}return t.prototype.render=function(){return n(\\
 "
 `;
 
+exports[`fixtures build macro with microbundle 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+macro
+  dist
+    macro-lib.js
+    macro-lib.js.map
+    macro-lib.mjs
+    macro-lib.mjs.map
+    macro-lib.umd.js
+    macro-lib.umd.js.map
+  package.json
+  src
+    index.js
+    macro.js
+
+
+Build \\"macroLib\\" to dist:
+49 B: macro-lib.js.gz
+33 B: macro-lib.js.br
+48 B: macro-lib.mjs.gz
+32 B: macro-lib.mjs.br
+157 B: macro-lib.umd.js.gz
+125 B: macro-lib.umd.js.br"
+`;
+
+exports[`fixtures build macro with microbundle 2`] = `6`;
+
+exports[`fixtures build macro with microbundle 3`] = `
+"module.exports=\\"name-macro\\";
+//# sourceMappingURL=macro-lib.js.map
+"
+`;
+
+exports[`fixtures build macro with microbundle 4`] = `
+"export default\\"name-macro\\";
+//# sourceMappingURL=macro-lib.mjs.map
+"
+`;
+
+exports[`fixtures build macro with microbundle 5`] = `
+"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=\\"name-macro\\":\\"function\\"==typeof define&&define.amd?define(function(){return\\"name-macro\\"}):(e=e||self).macroLib=\\"name-macro\\"}(this);
+//# sourceMappingURL=macro-lib.umd.js.map
+"
+`;
+
 exports[`fixtures build name-custom-amd with microbundle 1`] = `
 "Used script: microbundle
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -225,30 +225,30 @@ basic-babelrc
 
 
 Build \\"basicBabelrc\\" to dist:
-94 B: basic-babelrc.js.gz
-75 B: basic-babelrc.js.br
-94 B: basic-babelrc.mjs.gz
-75 B: basic-babelrc.mjs.br
-139 B: basic-babelrc.umd.js.gz
-102 B: basic-babelrc.umd.js.br"
+122 B: basic-babelrc.js.gz
+91 B: basic-babelrc.js.br
+122 B: basic-babelrc.mjs.gz
+91 B: basic-babelrc.mjs.br
+158 B: basic-babelrc.umd.js.gz
+121 B: basic-babelrc.umd.js.br"
 `;
 
 exports[`fixtures build basic-babelrc with microbundle 2`] = `6`;
 
 exports[`fixtures build basic-babelrc with microbundle 3`] = `
-"!function(r=function(r){throw new Error(\\"required!\\")}()){!0===r||function(r){throw new Error(\\"Falsey!\\")}()}(!0);
+"function r(r){return void 0===r&&(r=function(r){throw new Error(\\"required!\\")}()),!0===r||function(r){throw new Error(\\"Falsey!\\")}()}r(!0),r(!1);
 //# sourceMappingURL=basic-babelrc.js.map
 "
 `;
 
 exports[`fixtures build basic-babelrc with microbundle 4`] = `
-"!function(r=function(r){throw new Error(\\"required!\\")}()){!0===r||function(r){throw new Error(\\"Falsey!\\")}()}(!0);
+"function r(r){return void 0===r&&(r=function(r){throw new Error(\\"required!\\")}()),!0===r||function(r){throw new Error(\\"Falsey!\\")}()}r(!0),r(!1);
 //# sourceMappingURL=basic-babelrc.mjs.map
 "
 `;
 
 exports[`fixtures build basic-babelrc with microbundle 5`] = `
-"!function(n){\\"function\\"==typeof define&&define.amd?define(n):n()}(function(){!function(n=function(n){throw new Error(\\"required!\\")}()){!0===n||function(n){throw new Error(\\"Falsey!\\")}()}(!0)});
+"!function(n){\\"function\\"==typeof define&&define.amd?define(n):n()}(function(){function n(n){return void 0===n&&(n=function(n){throw new Error(\\"required!\\")}()),!0===n||function(n){throw new Error(\\"Falsey!\\")}()}n(!0),n(!1)});
 //# sourceMappingURL=basic-babelrc.umd.js.map
 "
 `;

--- a/test/fixtures/basic-babelrc/src/index.js
+++ b/test/fixtures/basic-babelrc/src/index.js
@@ -3,3 +3,4 @@ function test(param = throw new Error('required!')) {
 }
 
 test(true);
+test(false);

--- a/test/fixtures/macro/package.json
+++ b/test/fixtures/macro/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "macro-lib"
+}

--- a/test/fixtures/macro/src/index.js
+++ b/test/fixtures/macro/src/index.js
@@ -1,0 +1,5 @@
+import { macro } from './macro';
+
+const name = macro();
+
+export default name;

--- a/test/fixtures/macro/src/macro.js
+++ b/test/fixtures/macro/src/macro.js
@@ -1,0 +1,20 @@
+import { createMacro } from 'babel-plugin-macros';
+
+function myMacro({ references, state, babel }) {
+	const { types: t } = babel;
+
+	references.default.forEach(referencePath => {
+		const parentPath = referencePath.findParent(t.isCallExpression);
+		let variableName = referencePath.findParent(t.isVariableDeclarator).node.id
+			.name;
+		if (
+			parentPath.node.arguments.length > 0 &&
+			parentPath.node.arguments[0] !== ''
+		) {
+			variableName = parentPath.node.arguments[0].value;
+		}
+		parentPath.replaceWith(t.stringLiteral(`${variableName}-macro`));
+	});
+}
+
+export const macro = createMacro(myMacro);

--- a/test/fixtures/macro/src/macro.js
+++ b/test/fixtures/macro/src/macro.js
@@ -3,7 +3,7 @@ import { createMacro } from 'babel-plugin-macros';
 function myMacro({ references, state, babel }) {
 	const { types: t } = babel;
 
-	references.default.forEach(referencePath => {
+	references.macro.forEach(referencePath => {
 		const parentPath = referencePath.findParent(t.isCallExpression);
 		let variableName = referencePath.findParent(t.isVariableDeclarator).node.id
 			.name;
@@ -17,4 +17,4 @@ function myMacro({ references, state, babel }) {
 	});
 }
 
-export const macro = createMacro(myMacro);
+module.exports = createMacro(myMacro);


### PR DESCRIPTION
I think it'd be very useful to support Babel macros out of the box, they allow to use Babel without additional configuration so they can improve a lot the developer experience without adding extra configuration to Microbundle.

Zero config tools such as create-react-app already support it.