### PR TITLE
Bugfix: still enable Terser optimizations when eval is used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -587,7 +587,7 @@ function createConfig(options, entry, format, writeMeta) {
 							warnings: true,
 							ecma: 5,
 							toplevel: format === 'cjs' || format === 'es',
-							mangle: Object.assign({}, minifyOptions.mangle || {}),
+							mangle: Object.assign({ eval: true }, minifyOptions.mangle || {}),
 							nameCache,
 						}),
 						nameCache && {


### PR DESCRIPTION
This fixes a bug where Microbundle's output is suboptimal if `eval()` or `new Function()` is used.