### PR TITLE
add mdx-deck-live-code to "Built with..." section

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Here's what's coming up for Microbundle:
 - [react-recomponent](https://github.com/philipp-spiess/react-recomponent) Reason-style reducer components for React using ES6 classes.
 - [brazilian-utils](https://github.com/brazilian-utils/brazilian-utils) Utils library for specific Brazilian businesses.
 - [react-hooks-lib](https://github.com/beizhedenglong/react-hooks-lib) A set of reusable react hooks.
+- [mdx-deck-live-code](https://github.com/JReinhold/mdx-deck-live-code) A library for [mdx-deck](https://github.com/jxnblk/mdx-deck) to do live React and JS coding directly in slides.
 
 ## 🥂 License
 


### PR DESCRIPTION
Microbundle is JUST the bundling tool I've been looking for, thanks for this!

I would be honoured to have my library mentioned in the "Built with Microbundle" section.

repo: https://github.com/JReinhold/mdx-deck-live-code
demo: https://reinhold.is/live-coding-in-slides