### PR TITLE
Add support for --alias

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -291,6 +291,9 @@ function createConfig(options, entry, format, writeMeta) {
 	if (options.multipleEntries) {
 		aliases['.'] = './' + basename(options.output);
 	}
+	if (options.alias) {
+		aliases = Object.assign(aliases, parseGlobals(options.alias));
+	}
 
 	const peerDeps = Object.keys(pkg.peerDependencies || {});
 	if (options.external === 'none') {

--- a/src/prog.js
+++ b/src/prog.js
@@ -24,6 +24,8 @@ export default handler => {
 		.option('--external', `Specify external dependencies, or 'none'`)
 		.option('--globals', `Specify globals dependencies, or 'none'`)
 		.example('microbundle --globals react=React,jquery=$')
+		.option('--alias', `Map imports to different modules`)
+		.example('microbundle --alias react=preact')
 		.option('--compress', 'Compress output using Terser', null)
 		.option('--strict', 'Enforce undefined global context and add "use strict"')
 		.option('--name', 'Specify name exposed in UMD builds')


### PR DESCRIPTION
Same config parsing and format as `--globals` and [`--define`](https://github.com/developit/microbundle/pull/312):

```sh
microbundle --alias debug=./debug.js
```