### PR TITLE
Move Rollup 'treeshake' value to be a part of inputOptions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -418,6 +418,9 @@ function createConfig(options, entry, format, writeMeta) {
 				}
 				return externalTest(id);
 			},
+			treeshake: {
+				propertyReadSideEffects: false,
+			},
 			plugins: []
 				.concat(
 					postcss({
@@ -592,9 +595,6 @@ function createConfig(options, entry, format, writeMeta) {
 			freeze: false,
 			esModule: false,
 			sourcemap: options.sourcemap,
-			treeshake: {
-				propertyReadSideEffects: false,
-			},
 			format,
 			name: options.name,
 			file: resolve(


### PR DESCRIPTION
This pull request moves the `treeshake` value that is passed to Rollup. Based on [the documentation](https://rollupjs.org/guide/en#inputoptions) it should be a part of the `inputOptions` object instead of `outputOptions`.