### PR TITLE
Use Terser's module mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -587,6 +587,7 @@ function createConfig(options, entry, format, writeMeta) {
 							warnings: true,
 							ecma: 5,
 							toplevel: format === 'cjs' || format === 'es',
+							module: format === 'es',
 							mangle: Object.assign({}, minifyOptions.mangle || {}),
 							nameCache,
 						}),


### PR DESCRIPTION
Not 100% sure this will do anything different than `toplevel:true`, but I figured it was worth checking.

What would be really nice would be if there was a way to have Terser avoid creating local names for functions that are exported, since that just wastes gzipped bytes.