### PR TITLE
Add compressor options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -400,6 +400,9 @@ function createConfig(options, entry, format, writeMeta) {
 			nameCache = JSON.parse(
 				fs.readFileSync(resolve(options.cwd, 'mangle.json'), 'utf8'),
 			);
+			if (nameCache.config) {
+				mangleOptions = Object.assign({}, mangleOptions || {}, nameCache.config);
+			}
 		} catch (e) {}
 	}
 	loadNameCache();
@@ -539,16 +542,16 @@ function createConfig(options, entry, format, writeMeta) {
 						terser({
 							sourcemap: true,
 							output: { comments: false },
-							compress: {
+							compress: Object.assign({
 								keep_infinity: true,
 								pure_getters: true,
 								global_defs: defines,
 								passes: 10,
-							},
+							}, mangleOptions.compress || {}),
 							warnings: true,
 							ecma: 5,
 							toplevel: format === 'cjs' || format === 'es',
-							mangle: {
+							mangle: Object.assign({
 								properties: mangleOptions
 									? {
 											regex: mangleOptions.regex
@@ -557,7 +560,7 @@ function createConfig(options, entry, format, writeMeta) {
 											reserved: mangleOptions.reserved || [],
 									  }
 									: false,
-							},
+							}, mangleOptions.mangle || {}),
 							nameCache,
 						}),
 						mangleOptions && {

--- a/src/index.js
+++ b/src/index.js
@@ -46,12 +46,14 @@ const toTerserLiteral = (value, name) => {
 
 // Normalize Terser options from microbundle's relaxed JSON format (mutates argument in-place)
 function normalizeMinifyOptions(minifyOptions) {
-	const mangle = minifyOptions.mangle  || (minifyOptions.mangle = {});
+	const mangle = minifyOptions.mangle || (minifyOptions.mangle = {});
 	let properties = mangle.properties;
 
 	// allow top-level "properties" key to override mangle.properties (including {properties:false}):
 	if (minifyOptions.properties != null) {
-		properties = mangle.properties = minifyOptions.properties && Object.assign(properties, minifyOptions.properties);
+		properties = mangle.properties =
+			minifyOptions.properties &&
+			Object.assign(properties, minifyOptions.properties);
 	}
 
 	// allow previous format ({ mangle:{regex:'^_',reserved:[]} }):
@@ -60,7 +62,7 @@ function normalizeMinifyOptions(minifyOptions) {
 		properties.regex = properties.regex || minifyOptions.regex;
 		properties.reserved = properties.reserved || minifyOptions.reserved;
 	}
-	
+
 	if (properties) {
 		if (properties.regex) properties.regex = new RegExp(properties.regex);
 		properties.reserved = [].concat(properties.reserved || []);
@@ -426,7 +428,11 @@ function createConfig(options, entry, format, writeMeta) {
 			);
 			// mangle.json can contain a "minify" field, same format as the pkg.mangle:
 			if (nameCache.minify) {
-				minifyOptions = Object.assign({}, minifyOptions || {}, nameCache.minify);
+				minifyOptions = Object.assign(
+					{},
+					minifyOptions || {},
+					nameCache.minify,
+				);
 			}
 		} catch (e) {}
 	}
@@ -569,12 +575,15 @@ function createConfig(options, entry, format, writeMeta) {
 						terser({
 							sourcemap: true,
 							output: { comments: false },
-							compress: Object.assign({
-								keep_infinity: true,
-								pure_getters: true,
-								global_defs: defines,
-								passes: 10,
-							}, minifyOptions.compress || {}),
+							compress: Object.assign(
+								{
+									keep_infinity: true,
+									pure_getters: true,
+									global_defs: defines,
+									passes: 10,
+								},
+								minifyOptions.compress || {},
+							),
 							warnings: true,
 							ecma: 5,
 							toplevel: format === 'cjs' || format === 'es',

--- a/src/index.js
+++ b/src/index.js
@@ -411,7 +411,7 @@ function createConfig(options, entry, format, writeMeta) {
 
 	let nameCache = {};
 	// Support "minify" field and legacy "mangle" field via package.json:
-	let minifyOptions = options.pkg.minify || options.pkg.mangle || false;
+	let minifyOptions = options.pkg.minify || options.pkg.mangle || {};
 
 	const useTypescript = extname(entry) === '.ts' || extname(entry) === '.tsx';
 
@@ -581,7 +581,7 @@ function createConfig(options, entry, format, writeMeta) {
 							mangle: Object.assign({}, minifyOptions.mangle || {}),
 							nameCache,
 						}),
-						mangleOptions && {
+						nameCache && {
 							// before hook
 							options: loadNameCache,
 							// after hook

--- a/src/index.js
+++ b/src/index.js
@@ -412,6 +412,7 @@ function createConfig(options, entry, format, writeMeta) {
 	// let rollupName = safeVariableName(basename(entry).replace(/\.js$/, ''));
 
 	let nameCache = {};
+	const bareNameCache = nameCache;
 	// Support "minify" field and legacy "mangle" field via package.json:
 	let minifyOptions = options.pkg.minify || options.pkg.mangle || {};
 
@@ -439,6 +440,8 @@ function createConfig(options, entry, format, writeMeta) {
 	loadNameCache();
 
 	normalizeMinifyOptions(minifyOptions);
+
+	if (nameCache === bareNameCache) nameCache = null;
 
 	let shebang;
 


### PR DESCRIPTION
This allows specifying Terser options in mangle.json or package.json. The old `"mangle"` field is still supported for legacy reasons alongside the new `"minify"` option.

```js
// in `mangle.json` or `package.json`:
{
  "minify": {
    // old/simple variant:
    "regex": "^_",
    // new: customize any terser options:
    "compress": {
      "hoist_vars": true,
      "reduce_funcs": false
    }
  }
}
```

This is useful for projects that are already structured with functions aimed at gzip compression optimization.