### PR TITLE
Correct default --target option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Just like `microbundle build`, but watches your source files and rebuilds on any
     -o, --output     Directory to place build files into
     -f, --format     Only build specified formats  (default es,cjs,umd)
     -w, --watch      Rebuilds on any change  (default false)
-    --target         Specify your target environment  (default node)
+    --target         Specify your target environment (node or web) (default web)
     --external       Specify external dependencies, or 'none'
     --globals        Specify globals dependencies, or 'none'
     --compress       Compress output using Terser  (default true)

--- a/src/prog.js
+++ b/src/prog.js
@@ -20,7 +20,7 @@ export default handler => {
 		.option('--output, -o', 'Directory to place build files into')
 		.option('--format, -f', 'Only build specified formats', 'es,cjs,umd')
 		.option('--watch, -w', 'Rebuilds on any change', false)
-		.option('--target', 'Specify your target environment', 'web')
+		.option('--target', 'Specify your target environment (node or web)', 'web')
 		.option('--external', `Specify external dependencies, or 'none'`)
 		.option('--globals', `Specify globals dependencies, or 'none'`)
 		.example('microbundle --globals react=React,jquery=$')


### PR DESCRIPTION
The default for `--target` was updated to `web` in 071861e374a1a13acb9e4a4c6cb6792fc0ff10cf but the README still shows the old default (`node`). This updates the README to show the correct default.

Also specifies `node` and `web` and the possible values for target. From what I understand, `node` is really the only special value and anything other than `node` will behave the same, but I think it is nice to have some suggestions.