### PR TITLE
Implement --define with babel-plugin-transform-replace-expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "asyncro": "^3.0.0",
     "autoprefixer": "^9.0.0",
     "babel-plugin-transform-async-to-promises": "^0.8.3",
+    "babel-plugin-transform-replace-expressions": "^0.2.0",
     "brotli-size": "^0.0.3",
     "camelcase": "^5.0.0",
     "chalk": "^2.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -28,20 +28,20 @@ const removeScope = name => name.replace(/^@.*\//, '');
 
 // Convert booleans and int define= values to literals.
 // This is more intuitive than `microbundle --define A=1` producing A="1".
-// See: https://github.com/terser-js/terser#conditional-compilation-api
-const toTerserLiteral = (value, name) => {
+const toReplacementExpression = (value, name) => {
 	// --define A="1",B='true' produces string:
 	const matches = value.match(/^(['"])(.+)\1$/);
 	if (matches) {
-		return [matches[2], name];
+		return [JSON.stringify(matches[2]), name];
 	}
 
 	// --define A=1,B=true produces int/boolean literal:
 	if (/^(true|false|\d+)$/i.test(value)) {
-		return [value, '@' + name];
+		return [value, name];
 	}
 
-	// default: behaviour from Terser (@prefix=1 produces expression/literal, unprefixed=1 produces string literal):
+	// default: string literal
+	return [JSON.stringify(value), name];
 };
 
 // Normalize Terser options from microbundle's relaxed JSON format (mutates argument in-place)
@@ -380,7 +380,7 @@ function createConfig(options, entry, format, writeMeta) {
 	if (options.define) {
 		defines = Object.assign(
 			defines,
-			parseMappingArgument(options.define, toTerserLiteral),
+			parseMappingArgument(options.define, toReplacementExpression),
 		);
 	}
 
@@ -508,6 +508,17 @@ function createConfig(options, entry, format, writeMeta) {
 							},
 						}),
 					!useTypescript && flow({ all: true, pretty: true }),
+					babel({
+						babelrc: false,
+						compact: false,
+						include: 'node_modules/**',
+						plugins: [
+							[
+								require.resolve('babel-plugin-transform-replace-expressions'),
+								{ replace: defines },
+							],
+						],
+					}),
 					// Only used for async await
 					babel({
 						// We mainly use bublé to transpile JS and only use babel to
@@ -519,6 +530,10 @@ function createConfig(options, entry, format, writeMeta) {
 						exclude: 'node_modules/**',
 						plugins: [
 							require.resolve('@babel/plugin-syntax-jsx'),
+							[
+								require.resolve('babel-plugin-transform-replace-expressions'),
+								{ replace: defines },
+							],
 							[
 								require.resolve('babel-plugin-transform-async-to-promises'),
 								{ inlineHelpers: true, externalHelpers: true },
@@ -582,7 +597,6 @@ function createConfig(options, entry, format, writeMeta) {
 								{
 									keep_infinity: true,
 									pure_getters: true,
-									global_defs: defines,
 									passes: 10,
 								},
 								minifyOptions.compress || {},

--- a/src/index.js
+++ b/src/index.js
@@ -510,6 +510,7 @@ function createConfig(options, entry, format, writeMeta) {
 					!useTypescript && flow({ all: true, pretty: true }),
 					babel({
 						babelrc: false,
+						configFile: false,
 						compact: false,
 						include: 'node_modules/**',
 						plugins: [

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -784,26 +784,26 @@ define
 
 
 Build \\"alias\\" to dist:
-50 B: alias.js.gz
-34 B: alias.js.br
-50 B: alias.mjs.gz
-34 B: alias.mjs.br
-141 B: alias.umd.js.gz
+55 B: alias.js.gz
+37 B: alias.js.br
+55 B: alias.mjs.gz
+37 B: alias.mjs.br
+143 B: alias.umd.js.gz
 105 B: alias.umd.js.br"
 `;
 
 exports[`fixtures define 2`] = `
-"console.log(\\"debug mode\\",!1);
+"console.log(\\"production mode\\",!1);
 "
 `;
 
 exports[`fixtures define 3`] = `
-"console.log(\\"debug mode\\",!1);
+"console.log(\\"production mode\\",!1);
 "
 `;
 
 exports[`fixtures define 4`] = `
-"!function(e,o){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?o():\\"function\\"==typeof define&&define.amd?define(o):o()}(0,function(){console.log(\\"debug mode\\",!0)});
+"!function(e,o){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?o():\\"function\\"==typeof define&&define.amd?define(o):o()}(0,function(){console.log(\\"production mode\\",!1)});
 "
 `;
 


### PR DESCRIPTION
This pull request implements the `--define` feature with [babel-plugin-transform-replace-expressions](https://github.com/jviide/babel-plugin-transform-replace-expressions) instead of using Terser. The Babel plugin is also applied to node_modules, because the transformation happens before bundling.

In the end this change allows things like using `--define DEBUG=true` for the following code and getting the expected result:
```js
const DEBUG = false;

if (DEBUG) {
  console.log("DEBUG!");
}
```
Previously it seemed that in a case like this Rollup's dead code elimination did its job before Terser had the chance to replace `DEBUG`. Therefore the corresponding `console.log` statement line got always removed.

There seems to be a very slight performance impact. Without any `--define` definitions bundling react, react-dom and vue packages together took 1 minute and 11 seconds before this change, and 1 minute and 13 seconds with this change. `--define process.env.NODE_ENV=production` evened out the difference, the changed version even being faster sometimes. The output sizes seemed to be comparable in both cases.