### PR TITLE
Fix failing tests by setting fixture test timeout to 11000ms

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,6 +13,7 @@ const rimraf = promisify(_rimraf);
 
 const FIXTURES_DIR = `${__dirname}/fixtures`;
 const DEFAULT_SCRIPT = 'microbundle';
+const TEST_TIMEOUT = 11000;
 
 const join = (arr, delimiter = '') => arr.join(delimiter);
 
@@ -61,49 +62,56 @@ describe('fixtures', () => {
 			return;
 		}
 
-		it(fixtureDir, async () => {
-			if (fixtureDir.endsWith('-with-cwd')) {
-				fixturePath = resolve(fixturePath, fixtureDir.replace('-with-cwd', ''));
-			}
+		it(
+			fixtureDir,
+			async () => {
+				if (fixtureDir.endsWith('-with-cwd')) {
+					fixturePath = resolve(
+						fixturePath,
+						fixtureDir.replace('-with-cwd', ''),
+					);
+				}
 
-			const dist = resolve(`${fixturePath}/dist`);
-			// clean up
-			await rimraf(dist);
-			await rimraf(resolve(`${fixturePath}/.rts2_cache_cjs`));
-			await rimraf(resolve(`${fixturePath}/.rts2_cache_es`));
-			await rimraf(resolve(`${fixturePath}/.rts2_cache_umd`));
+				const dist = resolve(`${fixturePath}/dist`);
+				// clean up
+				await rimraf(dist);
+				await rimraf(resolve(`${fixturePath}/.rts2_cache_cjs`));
+				await rimraf(resolve(`${fixturePath}/.rts2_cache_es`));
+				await rimraf(resolve(`${fixturePath}/.rts2_cache_umd`));
 
-			const script = await getBuildScript(fixturePath, DEFAULT_SCRIPT);
+				const script = await getBuildScript(fixturePath, DEFAULT_SCRIPT);
 
-			const prevDir = process.cwd();
-			process.chdir(resolve(fixturePath));
+				const prevDir = process.cwd();
+				process.chdir(resolve(fixturePath));
 
-			const parsedOpts = parseScript(script);
+				const parsedOpts = parseScript(script);
 
-			const output = await microbundle({
-				...parsedOpts,
-				cwd: parsedOpts.cwd !== '.' ? parsedOpts.cwd : resolve(fixturePath),
-			});
+				const output = await microbundle({
+					...parsedOpts,
+					cwd: parsedOpts.cwd !== '.' ? parsedOpts.cwd : resolve(fixturePath),
+				});
 
-			process.chdir(prevDir);
+				process.chdir(prevDir);
 
-			const printedDir = printTree([dirTree(fixturePath)]);
+				const printedDir = printTree([dirTree(fixturePath)]);
 
-			expect(
-				[
-					`Used script: ${script}`,
-					'Directory tree:',
-					printedDir,
-					strip(output),
-				].join('\n\n'),
-			).toMatchSnapshot();
-
-			fs.readdirSync(resolve(dist)).forEach(file => {
 				expect(
-					fs.readFileSync(resolve(dist, file)).toString('utf8'),
+					[
+						`Used script: ${script}`,
+						'Directory tree:',
+						printedDir,
+						strip(output),
+					].join('\n\n'),
 				).toMatchSnapshot();
-			});
-		});
+
+				fs.readdirSync(resolve(dist)).forEach(file => {
+					expect(
+						fs.readFileSync(resolve(dist, file)).toString('utf8'),
+					).toMatchSnapshot();
+				});
+			},
+			TEST_TIMEOUT,
+		);
 	});
 
 	it('should keep shebang', () => {


### PR DESCRIPTION
This pull request aims to fix failing tests by upping the timeout for fixture tests from 5000ms to 11000ms.

Currently the tests are failing for multiple pull requests and also for the master branch. These failures seem to be caused by the `esnext-ts` test taking longer than the default 5000ms test timeout allows. In those cases Jest fails the test and moves on to the next one. There is no cancellation mechanism, however, so the failed async test may still continue running. Effectively there are then two or more tests running concurrently within the same process, which can cause `process.chdir` calls go out of sync. See https://travis-ci.org/developit/microbundle/builds/508413269#L555 for an example.

This proposed "fix" doesn't really address the deeper causes (tests taking too long / relying on tests being executed strictly sequentially). Indeed, those causes may not even need to be addressed at all. All this pull request does is turn the timeouts up to eleven.

...Thousand.