### PR TITLE
Fix node-resolve warnings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -484,8 +484,7 @@ function createConfig(options, entry, format, writeMeta) {
 							}),
 						),
 					nodeResolve({
-						module: true,
-						jsnext: true,
+						mainFields: ['module', 'jsnext', 'main'],
 						browser: options.target !== 'node',
 					}),
 					commonjs({


### PR DESCRIPTION
The latest in-range version of [rollup-plugin-node-resolve](https://github.com/rollup/rollup-plugin-node-resolve) has deprecated some options which results in several annoying warning logs every time you build with `microbundle`.

This is a very simple change that fixes these warnings.

Before:

```
yarn install v1.15.2
warning ../package.json: No license field
[1/4] 🔍  Resolving packages...
success Already up-to-date.
$ npm run -s build
node-resolve: setting options.module is deprecated, please override options.mainFields instead
node-resolve: setting options.jsnext is deprecated, please override options.mainFields instead
node-resolve: setting options.module is deprecated, please override options.mainFields instead
node-resolve: setting options.jsnext is deprecated, please override options.mainFields instead
Build "microbundle" to dist:
       1528 B: cli.js.gz
       1324 B: cli.js.br
      7.04 kB: microbundle.js.gz
      6.26 kB: microbundle.js.br
node-resolve: setting options.module is deprecated, please override options.mainFields instead
node-resolve: setting options.jsnext is deprecated, please override options.mainFields instead
node-resolve: setting options.module is deprecated, please override options.mainFields instead
node-resolve: setting options.jsnext is deprecated, please override options.mainFields instead
Build "microbundle" to dist:
       1528 B: cli.js.gz
       1324 B: cli.js.br
      7.04 kB: microbundle.js.gz
      6.26 kB: microbundle.js.br
✨  Done in 7.70s.
```

After:

```
master* in ~/dev/temp/microbundle $ yarn
yarn install v1.15.2
warning ../package.json: No license field
[1/4] 🔍  Resolving packages...
success Already up-to-date.
$ npm run -s build
Build "microbundle" to dist:
       1528 B: cli.js.gz
       1324 B: cli.js.br
      7.05 kB: microbundle.js.gz
      6.27 kB: microbundle.js.br
Build "microbundle" to dist:
       1528 B: cli.js.gz
       1324 B: cli.js.br
      7.05 kB: microbundle.js.gz
      6.27 kB: microbundle.js.br
✨  Done in 7.59s.
```

**Note**: I believe that every single user of `microbundle` who reinstalls via a fresh `npm install` or `yarn install` will currently see these warnings, so it'd be great to get this resolved asap.

Thanks!