### PR TITLE
fix: pin core-js to 3.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@babel/preset-env": "^7.4.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.8.0",
-    "core-js": "^3.1.2",
+    "core-js": "3.1.3",
     "cross-env": "^5.2.0",
     "directory-tree": "^2.2.3",
     "eslint": "^5.16.0",


### PR DESCRIPTION
Downgrade `core-js` so microbundle will work again