### PR TITLE
feat: add support for custom tsconfig path

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Options
 	--sourcemap      Generate source map  (default true)
 	--raw            Show raw byte size  (default false)
 	--jsx            A custom JSX pragma like React.createElement (default: h)
-	--tsconfig       Specify your custom path to tsconfig.json for typescript project
+	--tsconfig       Specify the path to a custom tsconfig.json
 	-h, --help       Displays this message
 
 Examples

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Options
 	--sourcemap      Generate source map  (default true)
 	--raw            Show raw byte size  (default false)
 	--jsx            A custom JSX pragma like React.createElement (default: h)
+	--tsconfig       Specify your custom path to tsconfig.json for typescript project
 	-h, --help       Displays this message
 
 Examples
@@ -157,6 +158,7 @@ Examples
 	$ microbundle build --define API_KEY=1234
 	$ microbundle build --alias react=preact
 	$ microbundle watch --no-sourcemap # don't generate sourcemaps
+	$ microbundle build --tsconfig tsconfig.build.json
 ```
 
 ## 🛣 Roadmap

--- a/src/index.js
+++ b/src/index.js
@@ -536,6 +536,7 @@ function createConfig(options, entry, format, writeMeta) {
 									jsxFactory: options.jsx || 'h',
 								},
 							},
+							tsconfig: options.tsconfig,
 							tsconfigOverride: {
 								compilerOptions: {
 									target: 'esnext',

--- a/src/prog.js
+++ b/src/prog.js
@@ -43,10 +43,7 @@ export default handler => {
 			'--jsx',
 			'A custom JSX pragma like React.createElement (default: h)',
 		)
-		.option(
-			'--tsconfig',
-			'Specify the path to a custom tsconfig.json',
-		)
+		.option('--tsconfig', 'Specify the path to a custom tsconfig.json')
 		.example('microbundle build --tsconfig tsconfig.build.json');
 
 	prog

--- a/src/prog.js
+++ b/src/prog.js
@@ -45,7 +45,7 @@ export default handler => {
 		)
 		.option(
 			'--tsconfig',
-			'Specify your custom path to tsconfig.json for typescript project',
+			'Specify the path to a custom tsconfig.json',
 		)
 		.example('microbundle build --tsconfig tsconfig.build.json');
 

--- a/src/prog.js
+++ b/src/prog.js
@@ -42,7 +42,12 @@ export default handler => {
 		.option(
 			'--jsx',
 			'A custom JSX pragma like React.createElement (default: h)',
-		);
+		)
+		.option(
+			'--tsconfig',
+			'Specify your custom path to tsconfig.json for typescript project',
+		)
+		.example('microbundle build --tsconfig tsconfig.build.json');
 
 	prog
 		.command('build [...entries]', '', { default: true })


### PR DESCRIPTION
With `tsconfig.json` [extends](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#configuration-inheritance-with-extends) option, it is usually normal for a project to have multiple `tsconfig.json`s for different purposes, such as test, build, IDE IntelliSense, etc.

With this PR, a `tsconfig` option from cli can be passed down to `rollup-plugin-typescript2` when defined.