### PR TITLE
Support import JSX from JS file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -527,6 +527,7 @@ function createConfig(options, entry, format, writeMeta) {
 					nodeResolve({
 						mainFields: ['module', 'jsnext', 'main'],
 						browser: options.target !== 'node',
+						extensions: ['.mjs', '.js', '.jsx', '.json', '.node'],
 					}),
 					commonjs({
 						// use a regex to make sure to include eventual hoisted packages

--- a/src/index.js
+++ b/src/index.js
@@ -527,6 +527,7 @@ function createConfig(options, entry, format, writeMeta) {
 					nodeResolve({
 						mainFields: ['module', 'jsnext', 'main'],
 						browser: options.target !== 'node',
+						// defaults + .jsx
 						extensions: ['.mjs', '.js', '.jsx', '.json', '.node'],
 					}),
 					commonjs({


### PR DESCRIPTION
## Changes

- Support import JSX from JS file by adding JSX extension to `@rollup/plugin-node-resolve` plugin 

## Background

I have experience an error when importing `.jsx file` from `.js` file like

```
index.js -> A.jsx
```

will cause an error  

```
Could not resolve './A' from src/index.js
```

However, Importing `.jsx` file from TypeScript file (`.ts`) file is seems working fine except the the import is chaining more than 3 levels depth. 

```sh
index.ts -> A.jsx # This is fine
index.ts -> A.jsx  -> B.jsx # This is fine

index.ts -> A.jsx  -> B.jsx -> C.jsx 
# Error: Could not resolve './C' from src/jsx-components/B.jsx
```

To reproduce the issue

```sh
git clone -b import-jsx-error --single-branch git@github.com:n3tr/microbundle-example.git
cd microbundle-example

yarn

yarn build --jsx React.createElement ./src/index.js 
# or
yarn build --jsx React.createElement ./src/index.ts

```

---

I'm not really sure what is the root cause of the error, by adding extensions seems to fix the problem.