### PR TITLE
Set preferBuiltins:true for Node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -529,7 +529,7 @@ function createConfig(options, entry, format, writeMeta) {
 						browser: options.target !== 'node',
 						// defaults + .jsx
 						extensions: ['.mjs', '.js', '.jsx', '.json', '.node'],
-						preferBuiltins: options.target === 'node' ? true : undefined
+						preferBuiltins: options.target === 'node' ? true : undefined,
 					}),
 					commonjs({
 						// use a regex to make sure to include eventual hoisted packages

--- a/src/index.js
+++ b/src/index.js
@@ -529,6 +529,7 @@ function createConfig(options, entry, format, writeMeta) {
 						browser: options.target !== 'node',
 						// defaults + .jsx
 						extensions: ['.mjs', '.js', '.jsx', '.json', '.node'],
+						preferBuiltins: options.target === 'node' ? true : undefined
 					}),
 					commonjs({
 						// use a regex to make sure to include eventual hoisted packages


### PR DESCRIPTION
This option was enabled by default at some point in the node-resolve plugin, which should already have fixed #303 and #288. It still prints a warning though, which is illogical when we're compiling for a Node target. This silences that warning.