### PR TITLE
preferBuiltins: true for node, false for web

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -537,7 +537,7 @@ function createConfig(options, entry, format, writeMeta) {
 						browser: options.target !== 'node',
 						// defaults + .jsx
 						extensions: ['.mjs', '.js', '.jsx', '.json', '.node'],
-						preferBuiltins: options.target === 'node' ? true : undefined,
+						preferBuiltins: options.target === 'node',
 					}),
 					commonjs({
 						// use a regex to make sure to include eventual hoisted packages


### PR DESCRIPTION
I don't know why I had this as undefined. We never want to inline built-ins.