### PR TITLE
Fix babel modern

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -252,7 +252,9 @@ export default async function microbundle(inputOptions) {
 	let out = await series(
 		steps.map(config => async () => {
 			const { inputOptions, outputOptions } = config;
-			inputOptions.cache = cache;
+			if (inputOptions.cache !== false) {
+				inputOptions.cache = cache;
+			}
 			let bundle = await rollup(inputOptions);
 			cache = bundle;
 			await bundle.write(outputOptions);
@@ -498,6 +500,9 @@ function createConfig(options, entry, format, writeMeta) {
 
 	let config = {
 		inputOptions: {
+			// disable Rollup's cache for the modern build to prevent re-use of legacy transpiled modules:
+			cache: modern ? false : undefined,
+
 			input: entry,
 			external: id => {
 				if (id === 'babel-plugin-transform-async-to-promises/helpers') {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1562,7 +1562,6 @@ jsx
     jsx.umd.js
     jsx.umd.js.map
   index.js
-  node_modules
   package.json
 
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1562,6 +1562,7 @@ jsx
     jsx.umd.js
     jsx.umd.js.map
   index.js
+  node_modules
   package.json
 
 
@@ -1887,8 +1888,8 @@ modern-generators
 Build \\"modernGenerators\\" to dist:
 234 B: modern-generators.js.gz
 207 B: modern-generators.js.br
-233 B: modern-generators.modern.js.gz
-191 B: modern-generators.modern.js.br
+113 B: modern-generators.modern.js.gz
+92 B: modern-generators.modern.js.br
 233 B: modern-generators.esm.js.gz
 191 B: modern-generators.esm.js.br
 311 B: modern-generators.umd.js.gz
@@ -1910,7 +1911,7 @@ exports[`fixtures build modern-generators with microbundle 4`] = `
 `;
 
 exports[`fixtures build modern-generators with microbundle 5`] = `
-"var e=regeneratorRuntime.mark(r);function r(){var r;return regeneratorRuntime.wrap(function(e){for(;;)switch(e.prev=e.next){case 0:r=0;case 1:return e.next=4,r++;case 4:e.next=1;break;case 6:case\\"end\\":return e.stop()}},e)}export default function(){try{var e=r();return Promise.resolve([e.next().value,e.next().value])}catch(e){return Promise.reject(e)}}
+"export default async function(){const e=function*(){let e=0;for(;;)yield e++}();return[e.next().value,e.next().value]}
 //# sourceMappingURL=modern-generators.modern.js.map
 "
 `;


### PR DESCRIPTION
This actually fixes the problem that was causing modern output to often be transpiled to ES5 like the ESM output. Rollup caches transforms, so we have to disable that caching when performing the modern build. This avoids "bleeding" Babel transformations/config between modern and legacy builds (in either direction).

I believe this was the last thing left to do before we agreed on a 0.12 official release.