### PR TITLE
refactor: split utilities in separate files

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import microbundle from '.';
+import microbundle from './index';
 import prog from './prog';
 import { stdout } from './utils';
 import logError from './log-error';

--- a/src/index.js
+++ b/src/index.js
@@ -22,11 +22,12 @@ import { isDir, isFile, stdout, isTruthy, removeScope } from './utils';
 import { getSizeInfo } from './lib/compressed-size';
 import { normalizeMinifyOptions } from './lib/terser';
 import {
-	parseMappingArgumentAlias,
+	parseAliasArgument,
 	parseMappingArgument,
 	toReplacementExpression,
 } from './lib/option-normalization';
 import { getConfigFromPkgJson, getName } from './lib/package-info';
+import { shouldCssModules, cssModulesConfig } from './lib/css-modules';
 
 // Extensions to use when resolving modules
 const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.es6', '.es', '.mjs'];
@@ -309,9 +310,7 @@ function createConfig(options, entry, format, writeMeta) {
 		outputAliases['.'] = './' + basename(options.output);
 	}
 
-	const moduleAliases = options.alias
-		? parseMappingArgumentAlias(options.alias)
-		: [];
+	const moduleAliases = options.alias ? parseAliasArgument(options.alias) : [];
 	const aliasIds = moduleAliases.map(alias => alias.find);
 
 	const peerDeps = Object.keys(pkg.peerDependencies || {});
@@ -598,54 +597,4 @@ function createConfig(options, entry, format, writeMeta) {
 	};
 
 	return config;
-}
-
-function shouldCssModules(options) {
-	const passedInOption = processCssmodulesArgument(options);
-
-	// We should module when my-file.module.css or my-file.css
-	const moduleAllCss = passedInOption === true;
-
-	// We should module when my-file.module.css
-	const allowOnlySuffixModule = passedInOption === null;
-
-	return moduleAllCss || allowOnlySuffixModule;
-}
-
-function cssModulesConfig(options) {
-	const passedInOption = processCssmodulesArgument(options);
-	const isWatchMode = options.watch;
-	const hasPassedInScopeName = !(
-		typeof passedInOption === 'boolean' || passedInOption === null
-	);
-
-	if (shouldCssModules(options) || hasPassedInScopeName) {
-		let generateScopedName = isWatchMode
-			? '_[name]__[local]__[hash:base64:5]'
-			: '_[hash:base64:5]';
-
-		if (hasPassedInScopeName) {
-			generateScopedName = passedInOption; // would be the string from --css-modules "_[hash]".
-		}
-
-		return { generateScopedName };
-	}
-
-	return false;
-}
-
-/*
-This is done becuase if you use the cli default property, you get a primiatve "null" or "false",
-but when using the cli arguments, you always get back strings. This method aims at correcting those
-for both realms. So that both realms _convert_ into primatives.
-*/
-function processCssmodulesArgument(options) {
-	if (options['css-modules'] === 'true' || options['css-modules'] === true)
-		return true;
-	if (options['css-modules'] === 'false' || options['css-modules'] === false)
-		return false;
-	if (options['css-modules'] === 'null' || options['css-modules'] === null)
-		return null;
-
-	return options['css-modules'];
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import { resolve, relative, dirname, basename, extname } from 'path';
-import { green, red, yellow, white, blue } from 'kleur';
+import camelCase from 'camelcase';
+import escapeStringRegexp from 'escape-string-regexp';
+import { blue } from 'kleur';
 import { map, series } from 'asyncro';
 import glob from 'tiny-glob/sync';
 import autoprefixer from 'autoprefixer';
@@ -13,93 +15,18 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
 import alias from '@rollup/plugin-alias';
 import postcss from 'rollup-plugin-postcss';
-import gzipSize from 'gzip-size';
-import brotliSize from 'brotli-size';
-import prettyBytes from 'pretty-bytes';
 import typescript from 'rollup-plugin-typescript2';
 import json from '@rollup/plugin-json';
 import logError from './log-error';
-import { readFile, isDir, isFile, stdout, stderr, isTruthy } from './utils';
-import camelCase from 'camelcase';
-import escapeStringRegexp from 'escape-string-regexp';
-
-const removeScope = name => name.replace(/^@.*\//, '');
-
-// Convert booleans and int define= values to literals.
-// This is more intuitive than `microbundle --define A=1` producing A="1".
-const toReplacementExpression = (value, name) => {
-	// --define A="1",B='true' produces string:
-	const matches = value.match(/^(['"])(.+)\1$/);
-	if (matches) {
-		return [JSON.stringify(matches[2]), name];
-	}
-
-	// --define @assign=Object.assign replaces expressions with expressions:
-	if (name[0] === '@') {
-		return [value, name.substring(1)];
-	}
-
-	// --define A=1,B=true produces int/boolean literal:
-	if (/^(true|false|\d+)$/i.test(value)) {
-		return [value, name];
-	}
-
-	// default: string literal
-	return [JSON.stringify(value), name];
-};
-
-// Normalize Terser options from microbundle's relaxed JSON format (mutates argument in-place)
-function normalizeMinifyOptions(minifyOptions) {
-	const mangle = minifyOptions.mangle || (minifyOptions.mangle = {});
-	let properties = mangle.properties;
-
-	// allow top-level "properties" key to override mangle.properties (including {properties:false}):
-	if (minifyOptions.properties != null) {
-		properties = mangle.properties =
-			minifyOptions.properties &&
-			Object.assign(properties, minifyOptions.properties);
-	}
-
-	// allow previous format ({ mangle:{regex:'^_',reserved:[]} }):
-	if (minifyOptions.regex || minifyOptions.reserved) {
-		if (!properties) properties = mangle.properties = {};
-		properties.regex = properties.regex || minifyOptions.regex;
-		properties.reserved = properties.reserved || minifyOptions.reserved;
-	}
-
-	if (properties) {
-		if (properties.regex) properties.regex = new RegExp(properties.regex);
-		properties.reserved = [].concat(properties.reserved || []);
-	}
-}
-
-// Parses values of the form "$=jQuery,React=react" into key-value object pairs.
-const parseMappingArgument = (globalStrings, processValue) => {
-	const globals = {};
-	globalStrings.split(',').forEach(globalString => {
-		let [key, value] = globalString.split('=');
-		if (processValue) {
-			const r = processValue(value, key);
-			if (r !== undefined) {
-				if (Array.isArray(r)) {
-					[value, key] = r;
-				} else {
-					value = r;
-				}
-			}
-		}
-		globals[key] = value;
-	});
-	return globals;
-};
-
-// Parses values of the form "$=jQuery,React=react" into key-value object pairs.
-const parseMappingArgumentAlias = aliasStrings => {
-	return aliasStrings.split(',').map(str => {
-		let [key, value] = str.split('=');
-		return { find: key, replacement: value };
-	});
-};
+import { isDir, isFile, stdout, isTruthy, removeScope } from './utils';
+import { getSizeInfo } from './lib/compressed-size';
+import { normalizeMinifyOptions } from './lib/terser';
+import {
+	parseMappingArgumentAlias,
+	parseMappingArgument,
+	toReplacementExpression,
+} from './lib/option-normalization';
+import { getConfigFromPkgJson, getName } from './lib/package-info';
 
 // Extensions to use when resolving modules
 const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.es6', '.es', '.mjs'];
@@ -107,39 +34,6 @@ const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.es6', '.es', '.mjs'];
 const WATCH_OPTS = {
 	exclude: 'node_modules/**',
 };
-
-// Hoist function because something (rollup?) incorrectly removes it
-function formatSize(size, filename, type, raw) {
-	const pretty = raw ? `${size} B` : prettyBytes(size);
-	const color = size < 5000 ? green : size > 40000 ? red : yellow;
-	const MAGIC_INDENTATION = type === 'br' ? 13 : 10;
-	return `${' '.repeat(MAGIC_INDENTATION - pretty.length)}${color(
-		pretty,
-	)}: ${white(basename(filename))}.${type}`;
-}
-
-async function getSizeInfo(code, filename, raw) {
-	const gzip = formatSize(
-		await gzipSize(code),
-		filename,
-		'gz',
-		raw || code.length < 5000,
-	);
-	let brotli;
-	//wrap brotliSize in try/catch in case brotli is unavailable due to
-	//lower node version
-	try {
-		brotli = formatSize(
-			await brotliSize(code),
-			filename,
-			'br',
-			raw || code.length < 5000,
-		);
-	} catch (e) {
-		return gzip;
-	}
-	return gzip + '\n' + brotli;
-}
 
 export default async function microbundle(inputOptions) {
 	let options = { ...inputOptions };
@@ -274,67 +168,11 @@ export default async function microbundle(inputOptions) {
 		}),
 	);
 
+	const targetDir = relative(cwd, dirname(options.output)) || '.';
+	const banner = blue(`Build "${options.name}" to ${targetDir}:`);
 	return {
-		output:
-			blue(
-				`Build "${options.name}" to ${relative(cwd, dirname(options.output)) ||
-					'.'}:`,
-			) +
-			'\n   ' +
-			out.join('\n   '),
+		output: `${banner}\n   ${out.join('\n   ')}`,
 	};
-}
-
-async function getConfigFromPkgJson(cwd) {
-	try {
-		const pkgJSON = await readFile(resolve(cwd, 'package.json'), 'utf8');
-		const pkg = JSON.parse(pkgJSON);
-
-		return {
-			hasPackageJson: true,
-			pkg,
-		};
-	} catch (err) {
-		const pkgName = basename(cwd);
-
-		stderr(
-			// `Warn ${yellow(`no package.json found. Assuming a pkg.name of "${pkgName}".`)}`
-			yellow(
-				`${yellow().inverse(
-					'WARN',
-				)} no package.json found. Assuming a pkg.name of "${pkgName}".`,
-			),
-		);
-
-		let msg = String(err.message || err);
-		if (!msg.match(/ENOENT/)) stderr(`  ${red().dim(msg)}`);
-
-		return { hasPackageJson: false, pkg: { name: pkgName } };
-	}
-}
-
-const safeVariableName = name =>
-	camelCase(
-		removeScope(name)
-			.toLowerCase()
-			.replace(/((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g, ''),
-	);
-
-function getName({ name, pkgName, amdName, cwd, hasPackageJson }) {
-	if (!pkgName) {
-		pkgName = basename(cwd);
-		if (hasPackageJson) {
-			stderr(
-				yellow(
-					`${yellow().inverse(
-						'WARN',
-					)} missing package.json "name" field. Assuming "${pkgName}".`,
-				),
-			);
-		}
-	}
-
-	return { finalName: name || amdName || safeVariableName(pkgName), pkgName };
 }
 
 async function jsOrTs(cwd, filename) {

--- a/src/lib/compressed-size.js
+++ b/src/lib/compressed-size.js
@@ -1,0 +1,32 @@
+import { basename } from 'path';
+import { green, red, yellow, white } from 'kleur';
+import gzipSize from 'gzip-size';
+import brotliSize from 'brotli-size';
+import prettyBytes from 'pretty-bytes';
+
+function getPadLeft(str, width, char = ' ') {
+	return char.repeat(width - str.length);
+}
+
+function formatSize(size, filename, type, raw) {
+	const pretty = raw ? `${size} B` : prettyBytes(size);
+	const color = size < 5000 ? green : size > 40000 ? red : yellow;
+	const indent = getPadLeft(pretty, type === 'br' ? 13 : 10);
+	return `${indent}${color(pretty)}: ${white(basename(filename))}.${type}`;
+}
+
+export async function getSizeInfo(code, filename, raw) {
+	raw = raw || code.length < 5000;
+
+	const [gzip, brotli] = await Promise.all([
+		gzipSize(code).catch(() => null),
+		brotliSize(code).catch(() => null),
+	]);
+
+	let out = formatSize(gzip, filename, 'gz', raw);
+	if (brotli) {
+		out += '\n' + formatSize(brotli, filename, 'br', raw);
+	}
+
+	return out;
+}

--- a/src/lib/css-modules.js
+++ b/src/lib/css-modules.js
@@ -1,0 +1,49 @@
+export function shouldCssModules(options) {
+	const passedInOption = processCssmodulesArgument(options);
+
+	// We should module when my-file.module.css or my-file.css
+	const moduleAllCss = passedInOption === true;
+
+	// We should module when my-file.module.css
+	const allowOnlySuffixModule = passedInOption === null;
+
+	return moduleAllCss || allowOnlySuffixModule;
+}
+
+export function cssModulesConfig(options) {
+	const passedInOption = processCssmodulesArgument(options);
+	const isWatchMode = options.watch;
+	const hasPassedInScopeName = !(
+		typeof passedInOption === 'boolean' || passedInOption === null
+	);
+
+	if (shouldCssModules(options) || hasPassedInScopeName) {
+		let generateScopedName = isWatchMode
+			? '_[name]__[local]__[hash:base64:5]'
+			: '_[hash:base64:5]';
+
+		if (hasPassedInScopeName) {
+			generateScopedName = passedInOption; // would be the string from --css-modules "_[hash]".
+		}
+
+		return { generateScopedName };
+	}
+
+	return false;
+}
+
+/**
+ * This is done because if you use the cli default property, you get a primiatve "null" or "false",
+ * but when using the cli arguments, you always get back strings. This method aims at correcting those
+ * for both realms. So that both realms _convert_ into primatives.
+ */
+function processCssmodulesArgument(options) {
+	if (options['css-modules'] === 'true' || options['css-modules'] === true)
+		return true;
+	if (options['css-modules'] === 'false' || options['css-modules'] === false)
+		return false;
+	if (options['css-modules'] === 'null' || options['css-modules'] === null)
+		return null;
+
+	return options['css-modules'];
+}

--- a/src/lib/option-normalization.js
+++ b/src/lib/option-normalization.js
@@ -1,0 +1,56 @@
+/**
+ * Convert booleans and int define= values to literals.
+ * This is more intuitive than `microbundle --define A=1` producing A="1".
+ */
+export function toReplacementExpression(value, name) {
+	// --define A="1",B='true' produces string:
+	const matches = value.match(/^(['"])(.+)\1$/);
+	if (matches) {
+		return [JSON.stringify(matches[2]), name];
+	}
+
+	// --define @assign=Object.assign replaces expressions with expressions:
+	if (name[0] === '@') {
+		return [value, name.substring(1)];
+	}
+
+	// --define A=1,B=true produces int/boolean literal:
+	if (/^(true|false|\d+)$/i.test(value)) {
+		return [value, name];
+	}
+
+	// default: string literal
+	return [JSON.stringify(value), name];
+}
+
+/**
+ * Parses values of the form "$=jQuery,React=react" into key-value object pairs.
+ */
+export function parseMappingArgument(globalStrings, processValue) {
+	const globals = {};
+	globalStrings.split(',').forEach(globalString => {
+		let [key, value] = globalString.split('=');
+		if (processValue) {
+			const r = processValue(value, key);
+			if (r !== undefined) {
+				if (Array.isArray(r)) {
+					[value, key] = r;
+				} else {
+					value = r;
+				}
+			}
+		}
+		globals[key] = value;
+	});
+	return globals;
+}
+
+/**
+ * Parses values of the form "$=jQuery,React=react" into key-value object pairs.
+ */
+export function parseMappingArgumentAlias(aliasStrings) {
+	return aliasStrings.split(',').map(str => {
+		let [key, value] = str.split('=');
+		return { find: key, replacement: value };
+	});
+}

--- a/src/lib/option-normalization.js
+++ b/src/lib/option-normalization.js
@@ -48,7 +48,7 @@ export function parseMappingArgument(globalStrings, processValue) {
 /**
  * Parses values of the form "$=jQuery,React=react" into key-value object pairs.
  */
-export function parseMappingArgumentAlias(aliasStrings) {
+export function parseAliasArgument(aliasStrings) {
 	return aliasStrings.split(',').map(str => {
 		let [key, value] = str.split('=');
 		return { find: key, replacement: value };

--- a/src/lib/package-info.js
+++ b/src/lib/package-info.js
@@ -1,0 +1,43 @@
+import { resolve, basename } from 'path';
+import { red, yellow } from 'kleur';
+import { readFile, stderr, safeVariableName } from '../utils';
+
+/** */
+export async function getConfigFromPkgJson(cwd) {
+	let hasPackageJson = false;
+	let pkg;
+	try {
+		const packageJson = await readFile(resolve(cwd, 'package.json'), 'utf8');
+		pkg = JSON.parse(packageJson);
+		hasPackageJson = true;
+	} catch (err) {
+		const pkgName = basename(cwd);
+
+		stderr(
+			yellow().inverse('WARN'),
+			yellow(` no package.json, assuming package name is "${pkgName}".`),
+		);
+
+		let msg = String(err.message || err);
+		if (!msg.match(/ENOENT/)) stderr(`  ${red().dim(msg)}`);
+
+		pkg = { name: pkgName };
+	}
+
+	return { hasPackageJson, pkg };
+}
+export function getName({ name, pkgName, amdName, cwd, hasPackageJson }) {
+	if (!pkgName) {
+		pkgName = basename(cwd);
+		if (hasPackageJson) {
+			stderr(
+				yellow().inverse('WARN'),
+				yellow(` missing package.json "name" field. Assuming "${pkgName}".`),
+			);
+		}
+	}
+
+	const finalName = name || amdName || safeVariableName(pkgName);
+
+	return { finalName, pkgName };
+}

--- a/src/lib/terser.js
+++ b/src/lib/terser.js
@@ -1,0 +1,24 @@
+// Normalize Terser options from microbundle's relaxed JSON format (mutates argument in-place)
+export function normalizeMinifyOptions(minifyOptions) {
+	const mangle = minifyOptions.mangle || (minifyOptions.mangle = {});
+	let properties = mangle.properties;
+
+	// allow top-level "properties" key to override mangle.properties (including {properties:false}):
+	if (minifyOptions.properties != null) {
+		properties = mangle.properties =
+			minifyOptions.properties &&
+			Object.assign(properties, minifyOptions.properties);
+	}
+
+	// allow previous format ({ mangle:{regex:'^_',reserved:[]} }):
+	if (minifyOptions.regex || minifyOptions.reserved) {
+		if (!properties) properties = mangle.properties = {};
+		properties.regex = properties.regex || minifyOptions.regex;
+		properties.reserved = properties.reserved || minifyOptions.reserved;
+	}
+
+	if (properties) {
+		if (properties.regex) properties.regex = new RegExp(properties.regex);
+		properties.reserved = [].concat(properties.reserved || []);
+	}
+}

--- a/src/log-error.js
+++ b/src/log-error.js
@@ -1,7 +1,7 @@
 import { red, dim } from 'kleur';
 import { stderr } from './utils';
 
-export default function(err) {
+export default function logError(err) {
 	const error = err.error || err;
 	const description = `${error.name ? error.name + ': ' : ''}${error.message ||
 		error}`;

--- a/src/prog.js
+++ b/src/prog.js
@@ -1,5 +1,5 @@
 import sade from 'sade';
-let { version } = require('../package');
+let { version } = require('../package.json');
 
 const toArray = val => (Array.isArray(val) ? val : val == null ? [] : [val]);
 

--- a/src/prog.js
+++ b/src/prog.js
@@ -10,9 +10,19 @@ export default handler => {
 
 	const cmd = type => (str, opts) => {
 		opts.watch = opts.watch || type === 'watch';
-		opts.compress =
-			opts.compress != null ? opts.compress : opts.target !== 'node';
+
 		opts.entries = toArray(str || opts.entry).concat(opts._);
+
+		if (opts.compress != null) {
+			// Convert `--compress true/false/1/0` to booleans:
+			if (typeof opts.compress !== 'boolean') {
+				opts.compress = opts.compress !== 'false' && opts.compress !== '0';
+			}
+		} else {
+			// the default compress value is `true` for web, `false` for Node:
+			opts.compress = opts.target !== 'node';
+		}
+
 		handler(opts);
 	};
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,21 +1,24 @@
 import { promises as fs } from 'fs';
+import camelCase from 'camelcase';
 
 export const readFile = fs.readFile;
 
 export const stat = fs.stat;
 
-export const isDir = name =>
-	stat(name)
+export function isDir(name) {
+	return stat(name)
 		.then(stats => stats.isDirectory())
 		.catch(() => false);
+}
 
-export const isFile = name =>
-	stat(name)
+export function isFile(name) {
+	return stat(name)
 		.then(stats => stats.isFile())
 		.catch(() => false);
+}
 
-export const stdout = console.log.bind(console); // eslint-disable-line no-console
-
+// eslint-disable-next-line no-console
+export const stdout = console.log.bind(console);
 export const stderr = console.error.bind(console);
 
 export const isTruthy = obj => {
@@ -25,3 +28,18 @@ export const isTruthy = obj => {
 
 	return obj.constructor !== Object || Object.keys(obj).length > 0;
 };
+
+/** Remove a @scope/ prefix from a package name string */
+export const removeScope = name => name.replace(/^@.*\//, '');
+
+const INVALID_ES3_IDENT = /((^[^a-zA-Z]+)|[^\w.-])|([^a-zA-Z0-9]+$)/g;
+
+/**
+ * Turn a package name into a valid reasonably-unique variable name
+ * @param {string} name
+ */
+export function safeVariableName(name) {
+	const normalized = removeScope(name).toLowerCase();
+	const identifier = normalized.replace(INVALID_ES3_IDENT, '');
+	return camelCase(identifier);
+}


### PR DESCRIPTION
Extracted multiple utilities out of the main isFile

/utils.js
- isDir
- isFile
- stdout
- stderr
- isTruthy
- removeScope

/lib/compressed-size.js
- getSizeInfo

/lib/terser.js
- normalizeMinifyOptions

/lib-option-normalization.js
-	parseAliasArgument,
- parseMappingArgument
- toReplacementExpression

/lib/package-info
- getConfigFromPkgJson
- getName

/lib/css-modules
- shouldCssModules
- cssModulesConfig
