### PR TITLE
Allow import.meta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -709,6 +709,14 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.8.3.tgz",
+      "integrity": "sha512-vYiGd4wQ9gx0Lngb7+bPCwQXGK/PR6FeTIJ+TIOlq+OfOKG/kCAOO2+IBac3oMM9qV7/fU76hfcqxUaLKZf1hQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@babel/core": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "7.7.4",
+    "@babel/plugin-syntax-import-meta": "^7.8.3",
     "@babel/plugin-syntax-jsx": "^7.7.4",
     "@babel/plugin-transform-flow-strip-types": "^7.7.4",
     "@babel/plugin-transform-react-jsx": "^7.7.7",

--- a/src/lib/babel-custom.js
+++ b/src/lib/babel-custom.js
@@ -71,6 +71,9 @@ export default () => {
 					'plugin',
 					[
 						{
+							name: '@babel/plugin-syntax-import-meta',
+						},
+						{
 							name: '@babel/plugin-transform-react-jsx',
 							pragma: customOptions.pragma || 'h',
 							pragmaFrag: customOptions.pragmaFrag || 'Fragment',


### PR DESCRIPTION
This allows the use of `import.meta`, which is supported by Rollup but needs a plugin in order to be passed successfully through Babel.