### PR TITLE
Clear generated types before test run

### DIFF
--- a/tools/build-fixture.js
+++ b/tools/build-fixture.js
@@ -49,6 +49,7 @@ export const buildDirectory = async fixtureDir => {
 	const dist = resolve(`${fixturePath}/dist`);
 	// clean up
 	await rimraf(dist);
+	await rimraf(resolve(`${fixturePath}/types`));
 	await rimraf(resolve(`${fixturePath}/.rts2_cache_cjs`));
 	await rimraf(resolve(`${fixturePath}/.rts2_cache_es`));
 	await rimraf(resolve(`${fixturePath}/.rts2_cache_umd`));


### PR DESCRIPTION
- Clear generated type folder before running each test

~~Just cleared my `node_modules` and reinstalled them. From the looks of it the newer dependencies than what I had locally lead to some snapshot changes.~~

(_Turns out that this was caused by a different node version_)