### PR TITLE
Update option docs for --externals (default peerDependencies & dependencies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Options
 	-f, --format     Only build specified formats (any of modern,es,cjs,umd or iife) (default modern,es,cjs,umd)
 	-w, --watch      Rebuilds on any change  (default false)
 	--target         Specify your target environment (node or web)  (default web)
-	--external       Specify external dependencies, or 'none'
+	--external       Specify external dependencies, or 'none' (default peerDependencies from package.json)
 	--globals        Specify globals dependencies, or 'none'
 	--define         Replace constants with hard-coded values
 	--alias          Map imports to different modules

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Options
 	-f, --format     Only build specified formats (any of modern,es,cjs,umd or iife) (default modern,es,cjs,umd)
 	-w, --watch      Rebuilds on any change  (default false)
 	--target         Specify your target environment (node or web)  (default web)
-	--external       Specify external dependencies, or 'none' (default peerDependencies from package.json)
+	--external       Specify external dependencies, or 'none' (default peerDependencies and dependencies in package.json)
 	--globals        Specify globals dependencies, or 'none'
 	--define         Replace constants with hard-coded values
 	--alias          Map imports to different modules


### PR DESCRIPTION
Just a small clarification that the externals default is `peerDependencies` and `dependencies`.

(Not sure if this is *needed* as obviously this is a sensible default, but it wasn't clear until checking the code that we didn't need to have `external`s that mirrored `peerDependencies` like you might if setting up rollup from scratch)

https://github.com/developit/microbundle/blob/ded90ace965eabdf1707d1a75b20629513086775/src/index.js#L406