### PR TITLE
Fix TS failing if module is set to CommonJS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -583,6 +583,7 @@ function createConfig(options, entry, format, writeMeta) {
 							tsconfig: options.tsconfig,
 							tsconfigOverride: {
 								compilerOptions: {
+									module: 'ESNext',
 									target: 'esnext',
 								},
 							},

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -2514,3 +2514,65 @@ exports[`fixtures build ts-mixed-exports with microbundle 7`] = `
 //# sourceMappingURL=ts-mixed-exports.umd.js.map
 "
 `;
+
+exports[`fixtures build ts-module with microbundle 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+ts-module
+  dist
+    foo.d.ts
+    index.d.ts
+    ts-module.esm.js
+    ts-module.esm.js.map
+    ts-module.js
+    ts-module.js.map
+    ts-module.umd.js
+    ts-module.umd.js.map
+  node_modules
+  package.json
+  src
+    foo.ts
+    index.ts
+  tsconfig.json
+
+
+Build \\"tsModule\\" to dist:
+59 B: ts-module.js.gz
+42 B: ts-module.js.br
+65 B: ts-module.esm.js.gz
+49 B: ts-module.esm.js.br
+168 B: ts-module.umd.js.gz
+128 B: ts-module.umd.js.br"
+`;
+
+exports[`fixtures build ts-module with microbundle 2`] = `8`;
+
+exports[`fixtures build ts-module with microbundle 3`] = `
+"export declare function foo(): string;
+"
+`;
+
+exports[`fixtures build ts-module with microbundle 4`] = `
+"export declare function foobar(): string;
+"
+`;
+
+exports[`fixtures build ts-module with microbundle 5`] = `
+"function o(){return\\"foobar\\"}export{o as foobar};
+//# sourceMappingURL=ts-module.esm.js.map
+"
+`;
+
+exports[`fixtures build ts-module with microbundle 6`] = `
+"exports.foobar=function(){return\\"foobar\\"};
+//# sourceMappingURL=ts-module.js.map
+"
+`;
+
+exports[`fixtures build ts-module with microbundle 7`] = `
+"!function(e,o){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?o(exports):\\"function\\"==typeof define&&define.amd?define([\\"exports\\"],o):o((e=e||self).tsModule={})}(this,function(e){e.foobar=function(){return\\"foobar\\"}});
+//# sourceMappingURL=ts-module.umd.js.map
+"
+`;

--- a/test/fixtures/ts-module/package.json
+++ b/test/fixtures/ts-module/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "ts-module"
+}

--- a/test/fixtures/ts-module/src/foo.ts
+++ b/test/fixtures/ts-module/src/foo.ts
@@ -1,0 +1,3 @@
+export function foo() {
+	return 'foo';
+}

--- a/test/fixtures/ts-module/src/index.ts
+++ b/test/fixtures/ts-module/src/index.ts
@@ -1,0 +1,5 @@
+import { foo } from './foo';
+
+export function foobar() {
+	return foo() + 'bar';
+}

--- a/test/fixtures/ts-module/tsconfig.json
+++ b/test/fixtures/ts-module/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"compilerOptions": {
+		"module": "CommonJS"
+	}
+}


### PR DESCRIPTION
TypeScript builds must always have the esm format, otherwise bundling fails. Due to testing setups (mocha/jasmine/...) users may have explicitly declared the module type to be `CommonJS` in `tsconfig.json`. This breaks `microbundle`.

To fix this we can silently overwrite the specified module type to the one we need and let TS take care of the rest.