### PR TITLE
fix: set types declarationDir based on cwd (#643)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -364,6 +364,21 @@ async function getOutput({ cwd, output, pkgMain, pkgName }) {
 	return main;
 }
 
+function getDeclarationDir({ options, pkg }) {
+	const { cwd, output } = options;
+
+	let result = output;
+
+	if (pkg.types || pkg.typings) {
+		result = pkg.types || pkg.typings;
+		result = resolve(cwd, result);
+	}
+
+	result = dirname(result);
+
+	return result;
+}
+
 async function getEntries({ input, cwd }) {
 	let entries = (
 		await map([].concat(input), async file => {
@@ -567,9 +582,7 @@ function createConfig(options, entry, format, writeMeta) {
 								compilerOptions: {
 									sourceMap: options.sourcemap,
 									declaration: true,
-									declarationDir: dirname(
-										pkg.types || pkg.typings || options.output,
-									),
+									declarationDir: getDeclarationDir({ options, pkg }),
 									jsx: 'react',
 									jsxFactory:
 										// TypeScript fails to resolve Fragments when jsxFactory


### PR DESCRIPTION
This includes the change regarding: https://github.com/developit/microbundle/issues/643#issuecomment-636536332

I tested it with `npm link` on my https://github.com/katywings/microbundle-test repository.