### PR TITLE
feat: add --pkg-main option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ Microbundle uses the fields from your `package.json` to figure out where it shou
 }
 ```
 
+### Building a single bundle with a fixed output name
+
+By default Microbundle outputs multiple bundles, one bundle per format. A single bundle with a fixed output name can be built like this:
+
+```bash
+microbundle -i lib/main.js -o dist/bundle.js --no-pkg-main -f umd
+```
+
 ### Mangling Properties
 
 To achieve the smallest possible bundle size, libraries often wish to rename internal object properties or class members to smaller names - transforming `this._internalIdValue` to `this._i`. Microbundle doesn't do this by default, however it can be enabled by creating a `mangle.json` file (or a `"mangle"` property in your package.json). Within that file, you can specify a regular expression pattern to control which properties should be mangled. For example: to mangle all property names beginning an underscore:
@@ -212,6 +220,7 @@ Options
 	-o, --output     Directory to place build files into
 	-f, --format     Only build specified formats (any of modern,es,cjs,umd or iife) (default modern,es,cjs,umd)
 	-w, --watch      Rebuilds on any change  (default false)
+	--pkg-main       Outputs files analog to package.json main entries  (default true)
 	--target         Specify your target environment (node or web)  (default web)
 	--external       Specify external dependencies, or 'none' (default peerDependencies and dependencies in package.json)
 	--globals        Specify globals dependencies, or 'none'

--- a/src/prog.js
+++ b/src/prog.js
@@ -28,6 +28,11 @@ export default handler => {
 			DEFAULT_FORMATS,
 		)
 		.option('--watch, -w', 'Rebuilds on any change', false)
+		.option(
+			'--pkg-main',
+			'Outputs files analog to package.json main entries',
+			true,
+		)
 		.option('--target', 'Specify your target environment (node or web)', 'web')
 		.option('--external', `Specify external dependencies, or 'none'`)
 		.option('--globals', `Specify globals dependencies, or 'none'`)

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -731,6 +731,38 @@ exports[`fixtures build basic-no-compress with microbundle 5`] = `
 "
 `;
 
+exports[`fixtures build basic-no-pkg-main with microbundle 1`] = `
+"Used script: microbundle --pkg-main false
+
+Directory tree:
+
+basic-no-pkg-main
+  dist
+    basic-no-pkg-main.js
+    basic-no-pkg-main.js.map
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"basicNoPkgMain\\" to dist:
+187 B: basic-no-pkg-main.js.gz
+138 B: basic-no-pkg-main.js.br
+188 B: basic-no-pkg-main.js.gz
+139 B: basic-no-pkg-main.js.br
+279 B: basic-no-pkg-main.js.gz
+229 B: basic-no-pkg-main.js.br"
+`;
+
+exports[`fixtures build basic-no-pkg-main with microbundle 2`] = `2`;
+
+exports[`fixtures build basic-no-pkg-main with microbundle 3`] = `
+"!function(e,r){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=r():\\"function\\"==typeof define&&define.amd?define(r):(e=e||self).basicNoPkgMain=r()}(this,function(){var e=function(){try{var e=arguments;return Promise.resolve([].slice.call(e).reduce(function(e,r){return e+r},0))}catch(e){return Promise.reject(e)}};return function(){try{var r=arguments,n=[].slice.call(r);return Promise.resolve(e.apply(void 0,n)).then(function(r){return Promise.resolve(e.apply(void 0,n)).then(function(e){return[r,e]})})}catch(e){return Promise.reject(e)}}});
+//# sourceMappingURL=basic-no-pkg-main.js.map
+"
+`;
+
 exports[`fixtures build basic-ts with microbundle 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/basic-no-pkg-main/package.json
+++ b/test/fixtures/basic-no-pkg-main/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "basic-no-pkg-main",
+  "scripts": {
+    "build": "microbundle --pkg-main false"
+  }
+}

--- a/test/fixtures/basic-no-pkg-main/src/index.js
+++ b/test/fixtures/basic-no-pkg-main/src/index.js
@@ -1,0 +1,5 @@
+import { two } from './two';
+
+export default async function(...args) {
+	return [await two(...args), await two(...args)];
+}

--- a/test/fixtures/basic-no-pkg-main/src/two.js
+++ b/test/fixtures/basic-no-pkg-main/src/two.js
@@ -1,0 +1,3 @@
+export async function two(...args) {
+	return args.reduce((total, value) => total + value, 0);
+}


### PR DESCRIPTION
The goal of this feature is to add a solution for microbundle, to manually disable the package.json / format suffix automations analog to https://twitter.com/Katy_Wings/status/1271189844077748224

The new option `--pkg-main` by default is true - basically notifying the consumer that main entries in package.json will be considered. The consumer can supply `--pkg-main false` to disable the microbundle package.json "sideffects".

This PR also includes a little refactor of the "main" generation - most of it is the same as before but just moved into separate functions.