### PR TITLE
Use DI to prevent multiple copies of @babel/core

### DIFF
--- a/src/lib/babel-custom.js
+++ b/src/lib/babel-custom.js
@@ -1,4 +1,3 @@
-import { createConfigItem } from '@babel/core';
 import { createBabelInputPluginFactory } from '@rollup/plugin-babel';
 import merge from 'lodash.merge';
 import transformFastRest from './transform-fast-rest';
@@ -49,7 +48,7 @@ const createConfigItems = (type, items) => {
 
 const presetEnvRegex = RegExp(/@babel\/(preset-)?env/);
 
-export default () => {
+export default ({ createConfigItem }) => {
 	return createBabelInputPluginFactory(babelCore => {
 		return {
 			// Passed the plugin options.


### PR DESCRIPTION
Here's the difference:

This uses the copy of `@babel/core` that is being used to transform and run plugins:

```js
export function custom(core) {
  return {
    config() {
      core.createConfigItem(...)
    }
  }
}
```

This uses the copy of `@babel/core` that npm installed for Microbundle, which may be different:

```js
import core from '@babel/core';
export function custom() {
  return {
    config() {
      core.createConfigItem(...)
    }
  }
}
```

Fixes #657.