### PR TITLE
Allow RegExp --externals only for the CLI argument

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -476,7 +476,7 @@ function createConfig(options, entry, format, writeMeta) {
 	}
 
 	let globals = external.reduce((globals, name) => {
-		// Use raw/escaped value for CLI-provided RegExp externals:
+		// Use raw value for CLI-provided RegExp externals:
 		if (name instanceof RegExp) name = name.source;
 
 		// valid JS identifiers are usually library globals:

--- a/src/index.js
+++ b/src/index.js
@@ -465,7 +465,10 @@ function createConfig(options, entry, format, writeMeta) {
 	if (options.external === 'none') {
 		// bundle everything (external=[])
 	} else if (options.external) {
-		external = external.concat(peerDeps).concat(options.external.split(','));
+		external = external.concat(peerDeps).concat(
+			// CLI --external supports regular expressions:
+			options.external.split(',').map(str => new RegExp(str)),
+		);
 	} else {
 		external = external
 			.concat(peerDeps)
@@ -507,8 +510,10 @@ function createConfig(options, entry, format, writeMeta) {
 
 	const useTypescript = extname(entry) === '.ts' || extname(entry) === '.tsx';
 
+	const escapeStringExternals = ext =>
+		ext instanceof RegExp ? ext.source : escapeStringRegexp(ext);
 	const externalPredicate = new RegExp(
-		`^(${external.map(escapeStringRegexp).join('|')})($|/)`,
+		`^(${external.map(escapeStringExternals).join('|')})($|/)`,
 	);
 	const externalTest =
 		external.length === 0 ? id => false : id => externalPredicate.test(id);

--- a/src/index.js
+++ b/src/index.js
@@ -476,6 +476,9 @@ function createConfig(options, entry, format, writeMeta) {
 	}
 
 	let globals = external.reduce((globals, name) => {
+		// Use raw/escaped value for CLI-provided RegExp externals:
+		if (name instanceof RegExp) name = name.source;
+
 		// valid JS identifiers are usually library globals:
 		if (name.match(/^[a-z_$][a-z0-9_$]*$/)) {
 			globals[name] = name;


### PR DESCRIPTION
This is an addendum to #650. It escapes externals that are generated from package.json or static lists, while still allowing regular expression `--externals` values from the command line argument.

/cc @katywings @krobing