### PR TITLE
fix: add externals with dash to globals (#643)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -482,8 +482,8 @@ function createConfig(options, entry, format, writeMeta) {
 		if (name instanceof RegExp) name = name.source;
 
 		// valid JS identifiers are usually library globals:
-		if (name.match(/^[a-z_$][a-z0-9_$]*$/)) {
-			globals[name] = name;
+		if (name.match(/^[a-z_$][a-z0-9_\-$]*$/)) {
+			globals[name] = camelCase(name);
 		}
 		return globals;
 	}, {});

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -428,6 +428,54 @@ exports[`fixtures build basic-css with microbundle 6`] = `
 "
 `;
 
+exports[`fixtures build basic-dashed-external with microbundle 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+basic-dashed-external
+  dist
+    basic-dashed-external.esm.js
+    basic-dashed-external.esm.js.map
+    basic-dashed-external.js
+    basic-dashed-external.js.map
+    basic-dashed-external.umd.js
+    basic-dashed-external.umd.js.map
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"basicDashedExternal\\" to dist:
+248 B: basic-dashed-external.js.gz
+188 B: basic-dashed-external.js.br
+214 B: basic-dashed-external.esm.js.gz
+164 B: basic-dashed-external.esm.js.br
+349 B: basic-dashed-external.umd.js.gz
+281 B: basic-dashed-external.umd.js.br"
+`;
+
+exports[`fixtures build basic-dashed-external with microbundle 2`] = `6`;
+
+exports[`fixtures build basic-dashed-external with microbundle 3`] = `
+"import r from\\"tiny-glob\\";var e=function(){try{var r=arguments;return Promise.resolve([].slice.call(r).reduce(function(r,e){return r+e},0))}catch(r){return Promise.reject(r)}};console.log(r);export default function(){try{var r=arguments,t=[].slice.call(r);return Promise.resolve(e.apply(void 0,t)).then(function(r){return Promise.resolve(e.apply(void 0,t)).then(function(e){return[r,e]})})}catch(r){return Promise.reject(r)}}
+//# sourceMappingURL=basic-dashed-external.esm.js.map
+"
+`;
+
+exports[`fixtures build basic-dashed-external with microbundle 4`] = `
+"var e,r=(e=require(\\"tiny-glob\\"))&&\\"object\\"==typeof e&&\\"default\\"in e?e.default:e,t=function(){try{var e=arguments;return Promise.resolve([].slice.call(e).reduce(function(e,r){return e+r},0))}catch(e){return Promise.reject(e)}};console.log(r),module.exports=function(){try{var e=arguments,r=[].slice.call(e);return Promise.resolve(t.apply(void 0,r)).then(function(e){return Promise.resolve(t.apply(void 0,r)).then(function(r){return[e,r]})})}catch(e){return Promise.reject(e)}};
+//# sourceMappingURL=basic-dashed-external.js.map
+"
+`;
+
+exports[`fixtures build basic-dashed-external with microbundle 5`] = `
+"!function(e,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=t(require(\\"tiny-glob\\")):\\"function\\"==typeof define&&define.amd?define([\\"tiny-glob\\"],t):(e=e||self).basicDashedExternal=t(e.tinyGlob)}(this,function(e){e=e&&Object.prototype.hasOwnProperty.call(e,\\"default\\")?e.default:e;var t=function(){try{var e=arguments;return Promise.resolve([].slice.call(e).reduce(function(e,t){return e+t},0))}catch(e){return Promise.reject(e)}};return console.log(e),function(){try{var e=arguments,r=[].slice.call(e);return Promise.resolve(t.apply(void 0,r)).then(function(e){return Promise.resolve(t.apply(void 0,r)).then(function(t){return[e,t]})})}catch(e){return Promise.reject(e)}}});
+//# sourceMappingURL=basic-dashed-external.umd.js.map
+"
+`;
+
 exports[`fixtures build basic-flow with microbundle 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/basic-dashed-external/package.json
+++ b/test/fixtures/basic-dashed-external/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "basic-dashed-external",
+  "scripts": {
+    "build": "microbundle"
+  },
+  "dependencies": {
+    "tiny-glob": "^0.2.6"
+  }
+}

--- a/test/fixtures/basic-dashed-external/src/index.js
+++ b/test/fixtures/basic-dashed-external/src/index.js
@@ -1,0 +1,8 @@
+import tinyglob from 'tiny-glob';
+console.log(tinyglob);
+
+import { two } from './two';
+
+export default async function(...args) {
+	return [await two(...args), await two(...args)];
+}

--- a/test/fixtures/basic-dashed-external/src/two.js
+++ b/test/fixtures/basic-dashed-external/src/two.js
@@ -1,0 +1,3 @@
+export async function two(...args) {
+	return args.reduce((total, value) => total + value, 0);
+}


### PR DESCRIPTION
I should go vacuum-cleaning now, but here is the short description:

## Is
Currently microbundle adds externals to globals - excluding externals with dash (`-`). This results in rollup detecting the missing explicit global and defining the global implicitly with the name camel cased. Also will rollup log a warning like: `No name was provided for external module 'microbundle-test' in output.globals – guessing 'microbundleTest`.

## Should
Since microbundle is adding the externals to globals by default, it should also include those with a dash as mentioned [here](https://github.com/developit/microbundle/issues/643#issuecomment-641071232) - and therefore avoid the `No name was provided` rollup warning. Since rollup handles its dash fallback by adding the external camel cased to globals, microbundle should also do the same.

The only real difference of this change should be, that we don't get the rollup warning `No name was provided for external module` for externals with dash.

## Considerations / Topics for further discussion
- I am not 100% sure how rollups camel casing implementation looks like - literally couldn't find it in rollups src. This means that rollups camelcasing and microbundles is potentially not the same - in this case this could be a breaking change.
- Since this fix is camel casing all externals for the globals, and not only those with a dash, there also is the chance that weird consumer externals like "Blub" will have a different automatic global name after this fix. I don't know any actual dependency that this would hit, but still want to mention it ;).


