### PR TITLE
Add onStart and onError callbacks, accessible rollup watchers

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -7,7 +7,7 @@ import logError from './log-error';
 
 const run = opts => {
 	microbundle(opts)
-		.then(output => {
+		.then(({ output }) => {
 			if (output != null) stdout(output);
 			if (!opts.watch) process.exit(0);
 		})

--- a/tools/build-fixture.js
+++ b/tools/build-fixture.js
@@ -60,11 +60,11 @@ export const buildDirectory = async fixtureDir => {
 	process.chdir(resolve(fixturePath));
 
 	const parsedOpts = parseScript(script);
-	let output = '';
-	output = await microbundle({
+	let { output } = await microbundle({
 		...parsedOpts,
 		cwd: parsedOpts.cwd !== '.' ? parsedOpts.cwd : resolve(fixturePath),
 	});
+	output = output || '';
 
 	process.chdir(prevDir);
 


### PR DESCRIPTION
Copied from the commit description ;)

- Adds onStart and onError microbundle js options:
onStart: is called when rollup noticed file changes and is starting with
bundling
onError: called if the rollup watcher is emitting any bundle errors

- Changes microbundle return type to:
```ts
{
  output?: string,
  watchers?: {
    "inputFileName": RollupWatcher
  }
}
```

- Removes obsolete rollup watch FATAL event handling