### PR TITLE
fix: dont set aliases as externals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -462,6 +462,7 @@ function createConfig(options, entry, format, writeMeta) {
 	const moduleAliases = options.alias
 		? parseMappingArgumentAlias(options.alias)
 		: [];
+	const aliasIds = moduleAliases.map(alias => alias.find);
 
 	const peerDeps = Object.keys(pkg.peerDependencies || {});
 	if (options.external === 'none') {
@@ -559,6 +560,9 @@ function createConfig(options, entry, format, writeMeta) {
 				}
 				if (options.multipleEntries && id === '.') {
 					return true;
+				}
+				if (aliasIds.indexOf(id) >= 0) {
+					return false;
 				}
 				return externalTest(id);
 			},

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -43,6 +43,54 @@ exports[`fixtures build alias with microbundle 5`] = `
 "
 `;
 
+exports[`fixtures build alias-external with microbundle 1`] = `
+"Used script: microbundle --alias tiny-glob=./colossal-glob.js
+
+Directory tree:
+
+alias-external
+  dist
+    alias-external.esm.js
+    alias-external.esm.js.map
+    alias-external.js
+    alias-external.js.map
+    alias-external.umd.js
+    alias-external.umd.js.map
+  package.json
+  src
+    colossal-glob.js
+    index.js
+
+
+Build \\"aliasExternal\\" to dist:
+37 B: alias-external.js.gz
+21 B: alias-external.js.br
+37 B: alias-external.esm.js.gz
+21 B: alias-external.esm.js.br
+93 B: alias-external.umd.js.gz
+89 B: alias-external.umd.js.br"
+`;
+
+exports[`fixtures build alias-external with microbundle 2`] = `6`;
+
+exports[`fixtures build alias-external with microbundle 3`] = `
+"console.log(42);
+//# sourceMappingURL=alias-external.esm.js.map
+"
+`;
+
+exports[`fixtures build alias-external with microbundle 4`] = `
+"console.log(42);
+//# sourceMappingURL=alias-external.js.map
+"
+`;
+
+exports[`fixtures build alias-external with microbundle 5`] = `
+"!function(n){\\"function\\"==typeof define&&define.amd?define(n):n()}(function(){console.log(42)});
+//# sourceMappingURL=alias-external.umd.js.map
+"
+`;
+
 exports[`fixtures build async-iife-ts with microbundle 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/alias-external/package.json
+++ b/test/fixtures/alias-external/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "alias-external",
+  "scripts": {
+    "build": "microbundle --alias tiny-glob=./colossal-glob.js"
+  },
+  "dependencies": {
+    "tiny-glob": "^0.2.6",
+    "lodash.merge": "^4.6.2"
+  }
+}

--- a/test/fixtures/alias-external/src/colossal-glob.js
+++ b/test/fixtures/alias-external/src/colossal-glob.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/fixtures/alias-external/src/index.js
+++ b/test/fixtures/alias-external/src/index.js
@@ -1,0 +1,2 @@
+import tinyglob from 'tiny-glob';
+console.log(tinyglob);


### PR DESCRIPTION
A module cannot be an alias and a external at the same time - rollup just ignores those aliases and keeps them as is.

IS: As example: if a module `X` is declared as external, the alias `X=Y` will not work, the bundle will just keep use `X`.

SHOULD: The alias `X=Y` should work even if `X` is declared as external.