### PR TITLE
refactor: use rollup dir and entryFileNames options instead of file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -559,6 +559,10 @@ function createConfig(options, entry, format, writeMeta) {
 	let cache;
 	if (modern) cache = false;
 
+	const absMain = resolve(options.cwd, getMain({ options, entry, format }));
+	const outputDir = dirname(absMain);
+	const outputEntryFileName = basename(absMain);
+
 	let config = {
 		/** @type {import('rollup').InputOptions} */
 		inputOptions: {
@@ -750,7 +754,8 @@ function createConfig(options, entry, format, writeMeta) {
 			},
 			format: modern ? 'es' : format,
 			name: options.name,
-			file: resolve(options.cwd, getMain({ options, entry, format })),
+			dir: outputDir,
+			entryFileNames: outputEntryFileName,
 		},
 	};
 


### PR DESCRIPTION
Refactoring the rollup output options to use a combination of `dir` and `entryFileNames`. Afaik this should not have any negative effects regarding the microbundle output whatsoever. But it enables dynamic import rollup support - as long as the consumer only uses output formats except of `umd` and `iife` :partying_face: 