### PR TITLE
Clarify typescript declarations directory doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Microbundle uses the fields from your `package.json` to figure out where it shou
   "umd:main": "dist/foo.umd.js",    // UMD bundle
   "module": "dist/foo.m.js",        // ES Modules bundle
   "esmodule": "dist/foo.modern.js", // Modern bundle
-  "types": "dist/foo.d.ts"          // TypeScript typings
+  "types": "dist/foo.d.ts"          // TypeScript typings directory
 }
 ```
 


### PR DESCRIPTION
Closes #673 

It's not possible to actually specify where to place the declarations file. This PR attempts to clarify the README.