### PR TITLE
[DOC] umd module default name is in camelCase not snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Unless overridden via the command line, microbundle uses the `source` property i
 }
 ```
 
-For UMD builds, microbundle will use a snake_case version of the `name` field in your `package.json` as export name. This can be customized using an `"amdName"` key in your `package.json` or the `--name` command line argument.
+For UMD builds, microbundle will use a camelCase version of the `name` field in your `package.json` as export name. This can be customized using an `"amdName"` key in your `package.json` or the `--name` command line argument.
 
 ### `microbundle watch`
 


### PR DESCRIPTION
unless I am mistaken the default export name for the module is in camelCase not snake_case