### PR TITLE
fix: disable node-builtin warnings

### DIFF
--- a/.changeset/tame-singers-grin.md
+++ b/.changeset/tame-singers-grin.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Disable warnings for node's builtin-modules when using node as a target environment.

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "babel-plugin-transform-replace-expressions": "^0.2.0",
     "brotli-size": "^4.0.0",
+    "builtin-modules": "^3.1.0",
     "camelcase": "^5.3.1",
     "cssnano": "^4.1.10",
     "es6-promisify": "^6.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import glob from 'tiny-glob/sync';
 import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano';
 import { rollup, watch } from 'rollup';
+import builtinModules from 'builtin-modules';
 import commonjs from '@rollup/plugin-commonjs';
 import babel from '@rollup/plugin-babel';
 import customBabel from './lib/babel-custom';
@@ -305,6 +306,12 @@ function createConfig(options, entry, format, writeMeta) {
 
 	const moduleAliases = options.alias ? parseAliasArgument(options.alias) : [];
 	const aliasIds = moduleAliases.map(alias => alias.find);
+
+	// We want to silence rollup warnings for node builtins as we rollup-node-resolve threats them as externals anyway
+	// @see https://github.com/rollup/plugins/tree/master/packages/node-resolve/#resolving-built-ins-like-fs
+	if (options.target === 'node') {
+		external = external.concat(builtinModules);
+	}
 
 	const peerDeps = Object.keys(pkg.peerDependencies || {});
 	if (options.external === 'none') {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -859,6 +859,47 @@ exports[`fixtures build basic-no-pkg-main with microbundle 3`] = `
 "
 `;
 
+exports[`fixtures build basic-node-internals with microbundle 1`] = `
+"Used script: microbundle --target=node -f cjs
+
+Directory tree:
+
+basic-node-internals
+  dist
+    basic-node-internals.js
+    basic-node-internals.js.map
+  package.json
+  src
+    index.js
+
+
+Build \\"basicNodeInternals\\" to dist:
+191 B: basic-node-internals.js.gz
+149 B: basic-node-internals.js.br"
+`;
+
+exports[`fixtures build basic-node-internals with microbundle 2`] = `2`;
+
+exports[`fixtures build basic-node-internals with microbundle 3`] = `
+"var child_process = require('child_process');
+
+function runCommand(cmd) {
+  return new Promise((resolve, reject) => {
+    child_process.exec(cmd, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+      }
+
+      resolve(stdout || stderr);
+    });
+  });
+}
+
+exports.runCommand = runCommand;
+//# sourceMappingURL=basic-node-internals.js.map
+"
+`;
+
 exports[`fixtures build basic-ts with microbundle 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/basic-node-internals/package.json
+++ b/test/fixtures/basic-node-internals/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "basic-node-internals",
+  "scripts": {
+    "build": "microbundle --target=node -f cjs"
+  }
+}

--- a/test/fixtures/basic-node-internals/src/index.js
+++ b/test/fixtures/basic-node-internals/src/index.js
@@ -1,0 +1,13 @@
+import { exec } from 'child_process';
+
+export function runCommand(cmd) {
+	return new Promise((resolve, reject) => {
+		exec(cmd, (error, stdout, stderr) => {
+			if (error) {
+				reject(error);
+			}
+
+			resolve(stdout || stderr);
+		});
+	});
+}


### PR DESCRIPTION
Disables warnings for node's builtin modules like stream, child_process when target is node. Rollup-node-resolve marks these modules as external but still shows a warning.

```
  console.warn node_modules/rollup/dist/shared/node-entry.js:13595  
    'child_process' is imported by src\index.js, but could not be resolved – treating it as an external dependency
```