### PR TITLE
chore: enable unpkg alias again

### DIFF
--- a/.changeset/tall-paws-end.md
+++ b/.changeset/tall-paws-end.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+re-enable unpkg alias for umd bundles as described in the readme

--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,7 @@ function getMain({ options, entry, format }) {
 	);
 	mainsByFormat.cjs = replaceName(pkg['cjs:main'] || 'x.js', mainNoExtension);
 	mainsByFormat.umd = replaceName(
-		pkg['umd:main'] || 'x.umd.js',
+		pkg['umd:main'] || pkg.unpkg || 'x.umd.js',
 		mainNoExtension,
 	);
 


### PR DESCRIPTION
It seems like we're missing the `unpkg` alias for `umd:main` that's defined in our README.md file. I've added it again.

Fixes https://github.com/developit/microbundle/issues/642