### PR TITLE
Support global extend via amdName

### DIFF
--- a/.changeset/chilled-paws-confess.md
+++ b/.changeset/chilled-paws-confess.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"microbundle": patch
 ---
 
-Support global extend via `{"amdName":"global.xyz"}` in package.json.
+Support [extending a UMD global](https://rollupjs.org/guide/en/#outputextend) by prefixing the package.json `"amdName"` field (eg: `"global.xyz"`).

--- a/.changeset/chilled-paws-confess.md
+++ b/.changeset/chilled-paws-confess.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Support global extend via `{"amdName":"global.xyz"}` in package.json.

--- a/src/index.js
+++ b/src/index.js
@@ -590,7 +590,8 @@ function createConfig(options, entry, format, writeMeta) {
 				return shebang[options.name];
 			},
 			format: modern ? 'es' : format,
-			name: options.name,
+			name: options.name && options.name.replace(/^global\./, ''),
+			extend: /^global\./.test(options.name),
 			dir: outputDir,
 			entryFileNames: outputEntryFileName,
 		},


### PR DESCRIPTION
Using a prefixed name like `{ "amdName": "global.foo" }` will trigger Rollup's `output.extend` option. This addresses the use-case from #709 without adding another CLI flag.