### PR TITLE
fix: bring back @babel/env preset match

### DIFF
--- a/src/lib/babel-custom.js
+++ b/src/lib/babel-custom.js
@@ -47,7 +47,7 @@ const createConfigItems = (babel, type, items) => {
 };
 
 const environmentPreset = '@babel/preset-env';
-// capture both @babel/env & @babel/preset-env
+// capture both @babel/env & @babel/preset-env (https://babeljs.io/docs/en/presets#preset-shorthand)
 const presetEnvRegex = new RegExp(/@babel\/(preset-)?env/);
 
 export default () => {

--- a/src/lib/babel-custom.js
+++ b/src/lib/babel-custom.js
@@ -47,7 +47,8 @@ const createConfigItems = (babel, type, items) => {
 };
 
 const environmentPreset = '@babel/preset-env';
-const presetEnvRegex = new RegExp(environmentPreset);
+// capture both @babel/env & @babel/preset-env
+const presetEnvRegex = new RegExp(/@babel\/(preset-)?env/);
 
 export default () => {
 	return createBabelInputPluginFactory(babelCore => {


### PR DESCRIPTION
@developit added @babel/env check again to microbundle. Npm doesn't have the package https://www.npmjs.com/package/@babel/env. It's the reason why I removed it so unsure what alias is meant in https://github.com/developit/microbundle/pull/702#discussion_r479397230. I'll change the comment in this PR to be more descriptive when I get more info.

Got removed in https://github.com/developit/microbundle/pull/702#discussion_r479397230

Note: this does not need a changeset