### PR TITLE
Support "esm" as an alias of "es" format

### DIFF
--- a/.changeset/hip-papayas-pretend.md
+++ b/.changeset/hip-papayas-pretend.md
@@ -1,0 +1,5 @@
+---
+"microbundle": patch
+---
+
+Support "esm" (`-f esm`) as an alias of "es" format.

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,8 @@ export default async function microbundle(inputOptions) {
 	options.multipleEntries = options.entries.length > 1;
 
 	let formats = (options.format || options.formats).split(',');
+	// de-dupe formats and convert "esm" to "es":
+	formats = Array.from(new Set(formats.map(f => f === 'esm' ? 'es' : f)));
 	// always compile cjs first if it's there:
 	formats.sort((a, b) => (a === 'cjs' ? -1 : a > b ? 1 : 0));
 

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ export default async function microbundle(inputOptions) {
 
 	let formats = (options.format || options.formats).split(',');
 	// de-dupe formats and convert "esm" to "es":
-	formats = Array.from(new Set(formats.map(f => f === 'esm' ? 'es' : f)));
+	formats = Array.from(new Set(formats.map(f => (f === 'esm' ? 'es' : f))));
 	// always compile cjs first if it's there:
 	formats.sort((a, b) => (a === 'cjs' ? -1 : a > b ? 1 : 0));
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1615,14 +1615,14 @@ Directory tree:
 
 define-expression
   dist
-    define-expression.js
+    define-expression.esm.js
   index.js
   package.json
 
 
 Build \\"defineExpression\\" to dist:
-56 B: define-expression.js.gz
-40 B: define-expression.js.br"
+56 B: define-expression.esm.js.gz
+40 B: define-expression.esm.js.br"
 `;
 
 exports[`fixtures build define-expression with microbundle 2`] = `1`;


### PR DESCRIPTION
I [constantly get tripped up by this](https://github.com/preactjs/legacy-compat/commit/e1f78210820c9ed66259f8fd7be58def66d5f019). Without this change, Microbundle compiles `-f esm` without any errors, but it actually writes an ES Module bundle to the configured CJS output file (even if there's also `-f cjs` listed). With this change, `-f esm` is identical to `-f es`.