### PR TITLE
docs: Fix simple typo, realy -> really

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -61,7 +61,7 @@ describe('fixtures', () => {
 			const dist = resolve(`${fixturePath}/dist`);
 			const files = fs.readdirSync(resolve(dist));
 			expect(files.length).toMatchSnapshot();
-			// we don't realy care about the content of a sourcemap
+			// we don't really care about the content of a sourcemap
 			files
 				.filter(
 					file =>


### PR DESCRIPTION
There is a small typo in test/index.test.js.

Should read `really` rather than `realy`.

