### PR TITLE
Use user's typescript first, fallback to bundled

### DIFF
--- a/.changeset/silver-guests-brake.md
+++ b/.changeset/silver-guests-brake.md
@@ -1,0 +1,5 @@
+---
+'microbundle': minor
+---
+
+Use user's typescript first, fallback to bundled

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "microbundle",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9228,6 +9228,13 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
       }
     },
     "import-from": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
 		"lodash.merge": "^4.6.2",
 		"module-details-from-path": "^1.0.3",
 		"pretty-bytes": "^5.3.0",
+		"resolve-from": "^4.0.0",
 		"rollup": "^1.32.1",
 		"rollup-plugin-bundle-size": "^1.0.1",
 		"rollup-plugin-es3": "^1.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -487,8 +487,10 @@ function createConfig(options, entry, format, writeMeta) {
 					},
 					useTypescript &&
 						typescript({
-							typescript: require(resolveFrom(process.cwd(), 'typescript') ||
-								'typescript'),
+							typescript: require(resolveFrom(
+								dirname(process.argv[1]),
+								'typescript',
+							) || 'typescript'),
 							cacheRoot: `./node_modules/.cache/.rts2_cache_${format}`,
 							useTsconfigDeclarationDir: true,
 							tsconfigDefaults: {

--- a/src/index.js
+++ b/src/index.js
@@ -403,6 +403,18 @@ function createConfig(options, entry, format, writeMeta) {
 	const outputDir = dirname(absMain);
 	const outputEntryFileName = basename(absMain);
 
+	const argv1 = process.argv[1];
+	let typescriptLibPath;
+	if (argv1 != null) {
+		// If argv1 exists, try to require 'typescript' from there.
+		typescriptLibPath = resolveFrom(dirname(argv1), 'typescript');
+	}
+	if (typescriptLibPath == null) {
+		// If argv1 doesn't exist or no 'typescript' found there,
+		// fallback to bundled 'typescript'.
+		typescriptLibPath = 'typescript';
+	}
+
 	let config = {
 		/** @type {import('rollup').InputOptions} */
 		inputOptions: {
@@ -487,10 +499,7 @@ function createConfig(options, entry, format, writeMeta) {
 					},
 					useTypescript &&
 						typescript({
-							typescript: require(resolveFrom(
-								dirname(process.argv[1]),
-								'typescript',
-							) || 'typescript'),
+							typescript: require(typescriptLibPath),
 							cacheRoot: `./node_modules/.cache/.rts2_cache_${format}`,
 							useTsconfigDeclarationDir: true,
 							tsconfigDefaults: {

--- a/src/index.js
+++ b/src/index.js
@@ -403,18 +403,6 @@ function createConfig(options, entry, format, writeMeta) {
 	const outputDir = dirname(absMain);
 	const outputEntryFileName = basename(absMain);
 
-	const argv1 = process.argv[1];
-	let typescriptLibPath;
-	if (argv1 != null) {
-		// If argv1 exists, try to require 'typescript' from there.
-		typescriptLibPath = resolveFrom(dirname(argv1), 'typescript');
-	}
-	if (typescriptLibPath == null) {
-		// If argv1 doesn't exist or no 'typescript' found there,
-		// fallback to bundled 'typescript'.
-		typescriptLibPath = 'typescript';
-	}
-
 	let config = {
 		/** @type {import('rollup').InputOptions} */
 		inputOptions: {
@@ -499,7 +487,10 @@ function createConfig(options, entry, format, writeMeta) {
 					},
 					useTypescript &&
 						typescript({
-							typescript: require(typescriptLibPath),
+							typescript: require(resolveFrom.silent(
+								options.cwd,
+								'typescript',
+							) || 'typescript'),
 							cacheRoot: `./node_modules/.cache/.rts2_cache_${format}`,
 							useTsconfigDeclarationDir: true,
 							tsconfigDefaults: {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano';
 import { rollup, watch } from 'rollup';
 import builtinModules from 'builtin-modules';
+import resolveFrom from 'resolve-from';
 import commonjs from '@rollup/plugin-commonjs';
 import babel from '@rollup/plugin-babel';
 import customBabel from './lib/babel-custom';
@@ -486,7 +487,8 @@ function createConfig(options, entry, format, writeMeta) {
 					},
 					useTypescript &&
 						typescript({
-							typescript: require('typescript'),
+							typescript: require(resolveFrom(process.cwd(), 'typescript') ||
+								'typescript'),
 							cacheRoot: `./node_modules/.cache/.rts2_cache_${format}`,
 							useTsconfigDeclarationDir: true,
 							tsconfigDefaults: {


### PR DESCRIPTION
This PR is aimed at fixing #711.

Microbundle will load "typescript" from `path.dirname(process.argv[1])`.

If no `process.argv[1]`, or failed to resolve "typescript" from there, fallback to the bundled "typescript".

P.S.
Using `resolve-from@v4.0.0` instead of the latest `v5.0.0` because `v4.0.0` has already been in `package-lock.json`.