### PR TITLE
Update examples to reference preact/compat instead of preact

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Options
 Examples
 	$ microbundle build --globals react=React,jquery=$
 	$ microbundle build --define API_KEY=1234
-	$ microbundle build --alias react=preact
+	$ microbundle build --alias react=preact/compat
 	$ microbundle watch --no-sourcemap # don't generate sourcemaps
 	$ microbundle build --tsconfig tsconfig.build.json
 ```


### PR DESCRIPTION
aliasing react=preact doesn't work because the main preact package actually doesn't contain any default exports. So the more likely example would be to reference preact/compat.