### PR TITLE
feat(config): allow override of rollup & plugins config by project config

### DIFF
--- a/src/lib/config-override.js
+++ b/src/lib/config-override.js
@@ -1,0 +1,43 @@
+import { isFile } from '../utils';
+import { resolve } from 'path';
+
+function configOverrider(projectOverride, context) {
+	return {
+		/**
+		 * Override the configuration for a given plugin.
+		 *
+		 * @param {string} pluginName
+		 * @param {Object} config the
+		 */
+		pluginConfig(pluginName, config) {
+			// No override if no plugins override is defined
+			if (!projectOverride.plugins) {
+				return config;
+			}
+
+			// Expect provided override to be a function returning modified config
+			const override = projectOverride.plugins[pluginName];
+			return override ? override(config, context) : config;
+		},
+
+		/**
+		 * Override the full rollup config before it's used
+		 *
+		 * @param {Object} config
+		 */
+		config(config) {
+			if (!projectOverride.config) {
+				return config;
+			}
+
+			return projectOverride.config(config, context);
+		},
+	};
+}
+
+export async function getConfigOverride(context) {
+	const path = resolve(context.options.cwd, 'microbundle.config.js');
+	const hasProjectConfig = await isFile(path);
+
+	return configOverrider(hasProjectConfig ? require(path) : {}, context);
+}


### PR DESCRIPTION
I love the simplicity of microbundle, but I need to do a bit more than what the default configuration it builds up provides.

More specifically, I want to be able to import SVG images.
Issue #679 says "for that we recommend going with rollup directly and writing a config for your needs.".

Given everything microbundle does for me, having to let it go and configure rollup myself just because of some SVG files makes me quite sad, so I pulled up this PoC of how microbundle could allow some customization of its build config.

@marvinhagemeister as you were the one making that statement in the SVG issue, maybe you'd be able to review/comment this?

It's quite "quick and dirty" for the moment, but I first wanted to know whether that could be a direction microbundle could take?

As a concrete example, that PR allows me to add a `microbundle.config.js` file into my project and support importing SVG files by importing the `@rollup/plugin-image` plugin:

```js
const image = require('@rollup/plugin-image')

module.exports = {
  plugins: {
    typescript: function (config) {
      // Since imported *.svg will be transformed to ES modules by the image plugin, tell
      // TypeScript to process them
      return { ...config, include: ['*.ts+(|x)', '**/*.ts+(|x)', '*.svg', '**/*.svg'] }
    },
  },

  config: function (config) {
    // Add image plugin right after json plugin
    const jsonIdx = config.inputOptions.plugins.findIndex((p) => p.name === 'json')
    config.inputOptions.plugins.splice(jsonIdx + 1, 0, image())
    return config
  },
}
```