### PR TITLE
feat: Add ESM Import Maps support

### DIFF
--- a/.changeset/two-ducks-shave.md
+++ b/.changeset/two-ducks-shave.md
@@ -1,0 +1,5 @@
+---
+'microbundle': minor
+---
+
+Support ESM Import Maps

--- a/package-lock.json
+++ b/package-lock.json
@@ -13645,6 +13645,11 @@
         }
       }
     },
+    "rollup-plugin-import-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-import-map/-/rollup-plugin-import-map-2.0.0.tgz",
+      "integrity": "sha512-Zb7EfWBoZaSecm2RJ353QWirvwOJv6PyviOapG0qZCCJX222DLDiVb9wEJL6KQW+b9QClnc+kEcVjifSOUQmew=="
+    },
     "rollup-plugin-postcss": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-2.9.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "microbundle",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13646,9 +13646,9 @@
       }
     },
     "rollup-plugin-import-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-import-map/-/rollup-plugin-import-map-2.0.0.tgz",
-      "integrity": "sha512-Zb7EfWBoZaSecm2RJ353QWirvwOJv6PyviOapG0qZCCJX222DLDiVb9wEJL6KQW+b9QClnc+kEcVjifSOUQmew=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-import-map/-/rollup-plugin-import-map-2.1.0.tgz",
+      "integrity": "sha512-MdZBCqaVSpzNQGlDoVZYtS2gF1a1/3br57jOLt3/R1ic5twvScN1egF2/PKUQ7CUvT3PC3diC9fVc9epKKwFvw=="
     },
     "rollup-plugin-postcss": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"rollup": "^1.32.1",
 		"rollup-plugin-bundle-size": "^1.0.1",
 		"rollup-plugin-es3": "^1.1.0",
+		"rollup-plugin-import-map": "^2.0.0",
 		"rollup-plugin-postcss": "^2.9.0",
 		"rollup-plugin-terser": "^5.3.0",
 		"rollup-plugin-typescript2": "^0.25.3",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"rollup": "^1.32.1",
 		"rollup-plugin-bundle-size": "^1.0.1",
 		"rollup-plugin-es3": "^1.1.0",
-		"rollup-plugin-import-map": "^2.0.0",
+		"rollup-plugin-import-map": "^2.1.0",
 		"rollup-plugin-postcss": "^2.9.0",
 		"rollup-plugin-terser": "^5.3.0",
 		"rollup-plugin-typescript2": "^0.25.3",

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano';
 import { rollup, watch } from 'rollup';
 import builtinModules from 'builtin-modules';
-import importMap from 'rollup-plugin-import-map';
+import { rollupImportMapPlugin as importMap } from 'rollup-plugin-import-map';
 import commonjs from '@rollup/plugin-commonjs';
 import babel from '@rollup/plugin-babel';
 import customBabel from './lib/babel-custom';

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano';
 import { rollup, watch } from 'rollup';
 import builtinModules from 'builtin-modules';
+import importMap from 'rollup-plugin-import-map';
 import commonjs from '@rollup/plugin-commonjs';
 import babel from '@rollup/plugin-babel';
 import customBabel from './lib/babel-custom';
@@ -351,6 +352,14 @@ function createConfig(options, entry, format, writeMeta) {
 		);
 	}
 
+	let imports = {};
+	if (options['import-map']) {
+		imports = Object.assign(
+			imports,
+			parseMappingArgument(options['import-map']),
+		);
+	}
+
 	const modern = format === 'modern';
 
 	// let rollupName = safeVariableName(basename(entry).replace(/\.js$/, ''));
@@ -443,6 +452,9 @@ function createConfig(options, entry, format, writeMeta) {
 
 			plugins: []
 				.concat(
+					(modern || format === 'es') &&
+						isTruthy(imports) &&
+						importMap({ imports }),
 					postcss({
 						plugins: [
 							autoprefixer(),

--- a/src/prog.js
+++ b/src/prog.js
@@ -51,6 +51,11 @@ export default handler => {
 		.example('microbundle --define API_KEY=1234')
 		.option('--alias', `Map imports to different modules`)
 		.example('microbundle --alias react=preact')
+		.option(
+			'--import-map',
+			`Import maps bare import specifiers to absolute URLs, when outputting ESM (-f esm,modern). Allows loading modules from a CDN at runtime, instead of bundling them at build time.`,
+		)
+		.example('microbundle --import-map preact=https://unpkg.com/preact?module')
 		.option('--compress', 'Compress output using Terser', null)
 		.option('--strict', 'Enforce undefined global context and add "use strict"')
 		.option('--name', 'Specify name exposed in UMD builds')

--- a/src/prog.js
+++ b/src/prog.js
@@ -53,7 +53,7 @@ export default handler => {
 		.example('microbundle --alias react=preact')
 		.option(
 			'--import-map',
-			`Import maps bare import specifiers to absolute URLs, when outputting ESM (-f esm,modern). Allows loading modules from a CDN at runtime, instead of bundling them at build time.`,
+			'Import ESM packages from a CDN, instead of including them in the ESM bundle',
 		)
 		.example('microbundle --import-map preact=https://unpkg.com/preact?module')
 		.option('--compress', 'Compress output using Terser', null)

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1687,6 +1687,32 @@ exports[`fixtures build esnext-ts with microbundle 6`] = `
 "
 `;
 
+exports[`fixtures build import-map with microbundle 1`] = `
+"Used script: microbundle -f modern --import-map web-vitals=https://unpkg.com/web-vitals/base?module
+
+Directory tree:
+
+import-map
+  dist
+    import-map.modern.js
+    import-map.modern.js.map
+  index.js
+  package.json
+
+
+Build \\"importMap\\" to dist:
+124 B: import-map.modern.js.gz
+107 B: import-map.modern.js.br"
+`;
+
+exports[`fixtures build import-map with microbundle 2`] = `2`;
+
+exports[`fixtures build import-map with microbundle 3`] = `
+"import{getCLS as o,getFID as l,getLCP as e}from\\"https://unpkg.com/web-vitals/base?module\\";o(console.log),l(console.log),e(console.log);
+//# sourceMappingURL=import-map.modern.js.map
+"
+`;
+
 exports[`fixtures build jsx with microbundle 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/import-map/index.js
+++ b/test/fixtures/import-map/index.js
@@ -1,0 +1,6 @@
+/* eslint-disable no-console */
+import { getLCP, getFID, getCLS } from 'web-vitals';
+
+getCLS(console.log);
+getFID(console.log);
+getLCP(console.log);

--- a/test/fixtures/import-map/package.json
+++ b/test/fixtures/import-map/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "import-map",
+  "scripts": {
+    "build": "microbundle -f modern --import-map web-vitals=https://unpkg.com/web-vitals/base?module"
+  }
+}


### PR DESCRIPTION
This follows up on @developit's [signal](https://github.com/developit/microbundle/pull/706#issuecomment-676516014) that ESM Import Maps is an interesting feature for microbundle.

# TL;DR
This PR is about supporting the [ahead-of-time rewriting](https://github.com/WICG/import-maps#ahead-of-time-rewriting) strategy that the [draft spec](https://github.com/WICG/import-maps) for ESM Import Maps talks about.

<details>
<summary>Background info, super detailed</summary>

At [FINN.no](https://www.finn.no/) we run a [diverse and distributed](https://medium.com/finn-no/infrastructure-at-finn-1c25c0fe3790) infra, with a constant stream of deployments that's only been interrupted when we moved data centers [in the middle of the night](https://medium.com/finn-no/how-finn-no-moved-800-microservices-to-the-cloud-in-5-hours-601067997620).

To make it possible for each team to own their part of the page (for example the Recommendations team owns the feed of "Anbefalinger" on the front page) and deploy updates and changes anytime they want we developed [Podium](https://podium-lib.io/). Podium answers the question "how can we update a snippet of shared html everywhere at once without restricting the server stack" by composing pages over HTTP. The benefits of a distributed frontend system are many, but it came with a challenging cost: if two page fragments use the same dependency, how do we ensure it's only ever downloaded once? 

We built [Asset Pipe](https://github.com/asset-pipe) to solve bundling for distributed systems. When a layout is starting up it figures out what assets each fragment needs, concatinates them, and sends them to our asset pipe server. When it's done bundling it'll create an optimized file for the js and another for the css, serving them on hashed URLs that are guaranteed to be unique:

```html
<link href="https://static.finncdn.no/_podium-assets/caeb0dc97f9e53242615f218cdb35b6ddb426e69b2803bc2e91e22e8a84a29d5.css" media="all" type="text/css" rel="stylesheet">
<script src="https://static.finncdn.no/_podium-assets/2a920eeee4c178549a1e1ca23869c55571750ddce280a16e4f8f07e0629539db.js" crossorigin defer></script>
```
The downside to this approach by "bundling as a service" is that bundling is a slow process and it's become a huge bottleneck. If a page fragment is deploying a new update it triggers bundling on each layout using it, causing a cascade of bundling processes starting up. We were also unhappy with the performance tradeoff by creating one hashed asset per layout that bundles everything. When a user moves from layout A to B ideally react shouldn't be redownloaded on layout B for example.

We decided to set out to replace Asset Pipe and explored different concepts to find the optimal trade-offs. It turns out that building a CDN asset service that is designed for ESM cache heuristics, HTTP2 and ESM Import Maps is a really good idea. We call this solution [Eik](https://eik.dev/).
It lets us publish assets to the CDN in a similar way as you would to npm, allowing assets to always be ready ahead-of-time for the page fragments that'll use them, with stable and immutable URLs. Making deployments as well as rollbacks fast as no bundling/rebundling is necessary.
The server part wasn't all we needed, we also had to create plugins for the bundlers people are using (rollup, esbuild, we're still waiting for webpack to support `libraryTarget: "module"` before we can add support there).

Many of our teams are used to the "bundling as a service" flow and don't have any bundler setup locally for their JSX or babel syntax. That's why we started looking at microbundle and saw it fit most of our needs, except that it didn't let us add custom rollup plugins and [we needed to make a fork](https://eik.dev/docs/mapping_bundling#why-we-forked-microbundle).

</details>

# How we're using Import Maps in production

At [FINN.no](https://www.finn.no/) we've been testing this in production for a couple of months now, in combination [with our ESM optimized CDN service](https://eik.dev/). By using ESM Import Maps as our foundation we've been able to dedupe shared dependencies like `react` in our distributed system.

Here's an example from our frontpage on what this looks like in production:
```html
       <script src="https://assets.finn.no/pkg/login-box/1.0.6/esm.js" type="module" crossorigin defer></script>
       <script src="https://assets.finn.no/pkg/login-box/1.0.6/ie11.js" crossorigin nomodule defer></script>
```

Browsers that support native ESM will load `esm.js` which Import Maps react like this:
```js
import e from"https://assets.finn.no/npm/@pika/react/v16/index.js";
import t from"https://assets.finn.no/npm/@pika/react-dom/v16/index.js";
```
The assets we import map to are aliased to latest major, similar to how unpkg.com works except we cache the 302 redirect for 20 minutes instead of 1 minute. This allows speeds things up considerably as the user browse around on our marketplace. We also use `-f modern` to generate the `esm.js` files to further reduce the amount of JS our users have to download. More info on the setup [in the docs](https://eik.dev/docs/mapping_bundling).

The performance results we've seen the last couple of months in production are promising and encouraging.  We believe that betting on the import map spec (over competing solutions like Webpack's Module Federation) is the way to go.