### PR TITLE
fix: Extra CSS files generated

### DIFF
--- a/.changeset/modern-students-give.md
+++ b/.changeset/modern-students-give.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Fixing a bug that would cause a CSS file to be generated to match each JS build output

--- a/src/index.js
+++ b/src/index.js
@@ -458,7 +458,7 @@ function createConfig(options, entry, format, writeMeta) {
 						// only write out CSS for the first bundle (avoids pointless extra files):
 						inject: false,
 						extract:
-              !!writeMeta &&
+							!!writeMeta &&
 							options.css !== 'inline' &&
 							options.output.replace(
 								/(\.(umd|cjs|es|m))?\.(mjs|[tj]sx?)$/,

--- a/src/index.js
+++ b/src/index.js
@@ -445,7 +445,7 @@ function createConfig(options, entry, format, writeMeta) {
 						modules: cssModulesConfig(options),
 						// only write out CSS for the first bundle (avoids pointless extra files):
 						inject: false,
-						extract: options.css !== 'inline',
+						extract: !!writeMeta && options.css !== 'inline',
 						minimize: options.compress,
 						sourceMap: options.sourcemap && options.css !== 'inline',
 					}),


### PR DESCRIPTION
## Summary

Fixes #776 

## Description

A bug with #769 meant that for each JS file output format (excluding UMD) a matching CSS file would be generated, i.e., `index.modern.css` and `index.module.css` (not a CSS module).

I corrected this by [restoring the old logic used](https://github.com/developit/microbundle/commit/967f8d532785aa7bf8636c5a759759a3e72dcf56#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L448), which was relying on `writeMeta`.