### PR TITLE
docs: Updating ReadMe to use correct path for "exports" field

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@
 
 ```js
 {
-  "name": "foo",                   // your package name
-  "source": "src/foo.js",          // your source code
-  "main": "dist/foo.js",           // where to generate the CommonJS/Node bundle
-  "exports": "dist/foo.modern.js", // path to the modern output (see below)
-  "module": "dist/foo.module.js",  // where to generate the ESM bundle
-  "unpkg": "dist/foo.umd.js",      // where to generate the UMD bundle (also aliased as "umd:main")
+  "name": "foo",                     // your package name
+  "source": "src/foo.js",            // your source code
+  "main": "dist/foo.js",             // where to generate the CommonJS/Node bundle
+  "exports": "./dist/foo.modern.js", // path to the modern output (see below)
+  "module": "dist/foo.module.js",    // where to generate the ESM bundle
+  "unpkg": "dist/foo.umd.js",        // where to generate the UMD bundle (also aliased as "umd:main")
   "scripts": {
-    "build": "microbundle",        // compiles "source" to "main"/"module"/"unpkg"
-    "dev": "microbundle watch"     // re-build when source files change
+    "build": "microbundle",          // compiles "source" to "main"/"module"/"unpkg"
+    "dev": "microbundle watch"       // re-build when source files change
   }
 }
 ```


### PR DESCRIPTION
## Summary

Corrects the `"exports"` field in one of the ReadMe sections to follow [the spec about exports' paths](https://nodejs.org/api/packages.html#packages_exports).

I did only update the `"exports"` field and left the others alone. Stylistically I'm not sure whether consistency is better or not here. The [block in the "Modern Mode" section](https://github.com/developit/microbundle#-modern-mode-) adds the `./` prefix to all fields but in other sections, where `"exports"` is omitted, `./` is not present.

Not sure what others' opinions are on the stylistic portion, but at least the field itself is correct to copy/paste with this PR