### PR TITLE
feat: Support customizing the modern output via "exports"

### DIFF
--- a/.changeset/tender-pants-film.md
+++ b/.changeset/tender-pants-film.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Allows users to customize the modern output's filename using "exports" like they can with "esmodules"

--- a/src/index.js
+++ b/src/index.js
@@ -285,7 +285,7 @@ function getMain({ options, entry, format }) {
 		mainNoExtension,
 	);
 	mainsByFormat.modern = replaceName(
-		(pkg.exports && walk(exports.exports)) ||
+		(pkg.exports && walk(pkg.exports)) ||
 			(pkg.syntax && pkg.syntax.esmodules) ||
 			pkg.esmodule ||
 			'x.modern.js',

--- a/src/index.js
+++ b/src/index.js
@@ -251,6 +251,11 @@ function replaceName(filename, name) {
 	);
 }
 
+function walk(exports) {
+	if (typeof exports === 'string') return exports;
+	return walk(exports['.'] || exports.import || exports.module);
+}
+
 function getMain({ options, entry, format }) {
 	const { pkg } = options;
 	const pkgMain = options['pkg-main'];
@@ -280,7 +285,7 @@ function getMain({ options, entry, format }) {
 		mainNoExtension,
 	);
 	mainsByFormat.modern = replaceName(
-		(typeof pkg.exports === 'string' && pkg.exports) ||
+		(pkg.exports && walk(exports.exports)) ||
 			(pkg.syntax && pkg.syntax.esmodules) ||
 			pkg.esmodule ||
 			'x.modern.js',

--- a/src/index.js
+++ b/src/index.js
@@ -280,7 +280,10 @@ function getMain({ options, entry, format }) {
 		mainNoExtension,
 	);
 	mainsByFormat.modern = replaceName(
-		(pkg.syntax && pkg.syntax.esmodules) || pkg.esmodule || 'x.modern.js',
+		(typeof pkg.exports === 'string' && pkg.exports) ||
+			(pkg.syntax && pkg.syntax.esmodules) ||
+			pkg.esmodule ||
+			'x.modern.js',
 		mainNoExtension,
 	);
 	mainsByFormat.cjs = replaceName(pkg['cjs:main'] || 'x.js', mainNoExtension);


### PR DESCRIPTION
## Summary

Closes #783 

Allows users to customize modern output file name with `exports` like they can with `esmodules`. 