### PR TITLE
enhance: support tsconfig esmodule interop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -504,7 +504,6 @@ function createConfig(options, entry, format, writeMeta) {
 									emitDeclarationOnly: options.generateTypes && !useTypescript,
 									declarationDir: getDeclarationDir({ options, pkg }),
 									jsx: 'preserve',
-									esModuleInterop: !!tsconfigOptions.esModuleInterop,
 									jsxFactory:
 										// TypeScript fails to resolve Fragments when jsxFactory
 										// is set, even when it's the same as the default value.

--- a/src/index.js
+++ b/src/index.js
@@ -504,7 +504,7 @@ function createConfig(options, entry, format, writeMeta) {
 									emitDeclarationOnly: options.generateTypes && !useTypescript,
 									declarationDir: getDeclarationDir({ options, pkg }),
 									jsx: 'preserve',
-									esModuleInterop: tsconfigOptions.esModuleInterop,
+									esModuleInterop: !!tsconfigOptions.esModuleInterop,
 									jsxFactory:
 										// TypeScript fails to resolve Fragments when jsxFactory
 										// is set, even when it's the same as the default value.
@@ -635,7 +635,7 @@ function createConfig(options, entry, format, writeMeta) {
 			globals,
 			strict: options.strict === true,
 			freeze: false,
-			esModule: useTypescript ? tsconfigOptions.esModuleInterop : false,
+			esModule: useTypescript ? !!tsconfigOptions.esModuleInterop : false,
 			sourcemap: options.sourcemap,
 			get banner() {
 				return shebang[options.name];

--- a/src/index.js
+++ b/src/index.js
@@ -400,18 +400,22 @@ function createConfig(options, entry, format, writeMeta) {
 	const absMain = resolve(options.cwd, getMain({ options, entry, format }));
 	const outputDir = dirname(absMain);
 	const outputEntryFileName = basename(absMain);
-	let tsconfigPath;
-	let tsconfigOptions = {};
 	let ts;
+	let tsconfigOptions = {};
 	if (useTypescript) {
-		tsconfigPath = resolve(
+		const tsconfigPath = resolve(
 			options.tsconfig || resolve(options.cwd, 'tsconfig.json'),
 		);
 		ts = require(resolveFrom.silent(options.cwd, 'typescript') || 'typescript');
-		const tsconfigJSON = ts.readConfigFile(tsconfigPath, ts.sys.readFile)
-			.config;
-		tsconfigOptions = ts.parseJsonConfigFileContent(tsconfigJSON, ts.sys, './')
-			.options;
+		if (fs.existsSync(tsconfigPath)) {
+			const tsconfigJSON = ts.readConfigFile(tsconfigPath, ts.sys.readFile)
+				.config;
+			tsconfigOptions = ts.parseJsonConfigFileContent(
+				tsconfigJSON,
+				ts.sys,
+				'./',
+			).options;
+		}
 	}
 
 	let config = {
@@ -513,7 +517,7 @@ function createConfig(options, entry, format, writeMeta) {
 								},
 								files: options.entries,
 							},
-							tsconfig: tsconfigPath,
+							tsconfig: options.tsconfig,
 							tsconfigOverride: {
 								compilerOptions: {
 									module: 'ESNext',

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -2782,3 +2782,59 @@ exports[`fixtures build ts-module with microbundle 7`] = `
 //# sourceMappingURL=ts-module.umd.js.map
 "
 `;
+
+exports[`fixtures build ts-module-interop with microbundle 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+ts-module-interop
+  dist
+    index.d.ts
+    ts-module.esm.js
+    ts-module.esm.js.map
+    ts-module.js
+    ts-module.js.map
+    ts-module.umd.js
+    ts-module.umd.js.map
+  node_modules
+  package.json
+  src
+    index.ts
+  tsconfig.json
+
+
+Build \\"tsModule\\" to dist:
+122 B: ts-module.js.gz
+91 B: ts-module.js.br
+87 B: ts-module.esm.js.gz
+73 B: ts-module.esm.js.br
+207 B: ts-module.umd.js.gz
+156 B: ts-module.umd.js.br"
+`;
+
+exports[`fixtures build ts-module-interop with microbundle 2`] = `7`;
+
+exports[`fixtures build ts-module-interop with microbundle 3`] = `
+"export default function foo(): string;
+export declare function hello(): string;
+"
+`;
+
+exports[`fixtures build ts-module-interop with microbundle 4`] = `
+"function r(){return\\"bar\\"}function t(){return\\"hello\\"}export default r;export{t as hello};
+//# sourceMappingURL=ts-module.esm.js.map
+"
+`;
+
+exports[`fixtures build ts-module-interop with microbundle 5`] = `
+"Object.defineProperty(exports,\\"__esModule\\",{value:!0}),exports.default=function(){return\\"bar\\"},exports.hello=function(){return\\"hello\\"};
+//# sourceMappingURL=ts-module.js.map
+"
+`;
+
+exports[`fixtures build ts-module-interop with microbundle 6`] = `
+"!function(e,o){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?o(exports):\\"function\\"==typeof define&&define.amd?define([\\"exports\\"],o):o((e||self).tsModule={})}(this,function(e){e.default=function(){return\\"bar\\"},e.hello=function(){return\\"hello\\"},Object.defineProperty(e,\\"__esModule\\",{value:!0})});
+//# sourceMappingURL=ts-module.umd.js.map
+"
+`;

--- a/test/fixtures/ts-module-interop/package.json
+++ b/test/fixtures/ts-module-interop/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "ts-module"
+}

--- a/test/fixtures/ts-module-interop/src/index.ts
+++ b/test/fixtures/ts-module-interop/src/index.ts
@@ -1,0 +1,5 @@
+export default function foo() {
+	return 'bar';
+}
+
+export function hello() { return 'hello' }

--- a/test/fixtures/ts-module-interop/tsconfig.json
+++ b/test/fixtures/ts-module-interop/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"module": "CommonJS",
+		"esModuleInterop": true
+	}
+}


### PR DESCRIPTION
### description

related to #531
when there's multiple exports in the source file while `esModuleInterop` specified as `true` in tsconfig compilerOptions, let rollup add `__esModule: {value: true}` mark to the output.

it will benefits the esmodule usage with the dist file when the dist is resolved to commonjs assets. the reason could be:
* only main field is existed in package.json
* due to some reason cjs assets is resolved instead of esmodule assets.

### changes
* respect `esModuleInterop` in tsconfig (for typescript source only)



