### PR TITLE
fix default extension to cjs for package.json "type":"module" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,11 @@ Importing CSS files is supported via `import "./foo.css"`. By default, generated
 
 ```js
 // with the default external CSS:
-import './foo.css';  // generates a minified .css file in the output directory
+import './foo.css'; // generates a minified .css file in the output directory
 
 // with `microbundle --css inline`:
 import css from './foo.css';
-console.log(css);  // the generated minified stylesheet
+console.log(css); // the generated minified stylesheet
 ```
 
 **CSS Modules:** CSS files with names ending in `.module.css` are treated as a [CSS Modules](https://github.com/css-modules/css-modules).
@@ -209,6 +209,18 @@ Microbundle uses the fields from your `package.json` to figure out where it shou
 }
 ```
 
+### `package.json` with `"type": "module"`
+
+Node.js >=13 with support for ES6 modules [will expect](https://nodejs.org/api/packages.html#packages_determining_module_system) all files with extention `.js` in a packages with `"type": "module"` to be ES6 Modules.
+To import a CommonJS bundle from this package the files need to have `.cjs` as the extention.
+
+```
+{
+  "main": "dist/foo.cjs",            // CommonJS bundle
+  "module": "dist/foo.m.js",        // ES Modules bundle
+}
+```
+
 ### Building a single bundle with a fixed output name
 
 By default Microbundle outputs multiple bundles, one bundle per format. A single bundle with a fixed output name can be built like this:
@@ -235,11 +247,11 @@ It's also possible to configure repeatable short names for each mangled property
 
 The `--define` option can be used to inject or replace build-time constants when bundling. In addition to injecting string or number constants, prefixing the define name with `@` allows injecting JavaScript expressions.
 
-| Build command | Source code | Output |
-|---------------|-------------|--------|
-`microbundle --define VERSION=2` | `console.log(VERSION)` | `console.log(2)`
-`microbundle --define API_KEY='abc123'` | `console.log(API_KEY)` | `console.log("abc123")`
-`microbundle --define @assign=Object.assign` | `assign(a, b)` | `Object.assign(a, b)`
+| Build command                                | Source code            | Output                  |
+| -------------------------------------------- | ---------------------- | ----------------------- |
+| `microbundle --define VERSION=2`             | `console.log(VERSION)` | `console.log(2)`        |
+| `microbundle --define API_KEY='abc123'`      | `console.log(API_KEY)` | `console.log("abc123")` |
+| `microbundle --define @assign=Object.assign` | `assign(a, b)`         | `Object.assign(a, b)`   |
 
 ### All CLI Options <a name="options"></a>
 

--- a/src/index.js
+++ b/src/index.js
@@ -263,13 +263,15 @@ function getMain({ options, entry, format }) {
 
 	let mainNoExtension = options.output;
 	if (options.multipleEntries) {
-		let name = entry.match(/([\\/])index(\.(umd|cjs|es|m))?\.(mjs|[tj]sx?)$/)
+		let name = entry.match(
+			/([\\/])index(\.(umd|cjs|es|m))?\.(mjs|cjs|[tj]sx?)$/,
+		)
 			? mainNoExtension
 			: entry;
 		mainNoExtension = resolve(dirname(mainNoExtension), basename(name));
 	}
 	mainNoExtension = mainNoExtension.replace(
-		/(\.(umd|cjs|es|m))?\.(mjs|[tj]sx?)$/,
+		/(\.(umd|cjs|es|m))?\.(mjs|cjs|[tj]sx?)$/,
 		'',
 	);
 
@@ -285,7 +287,10 @@ function getMain({ options, entry, format }) {
 		(pkg.syntax && pkg.syntax.esmodules) || pkg.esmodule || 'x.modern.js',
 		mainNoExtension,
 	);
-	mainsByFormat.cjs = replaceName(pkg['cjs:main'] || 'x.js', mainNoExtension);
+	mainsByFormat.cjs = replaceName(
+		pkg['cjs:main'] || (pkg.type && pkg.type === 'module' ? 'x.cjs' : 'x.js'),
+		mainNoExtension,
+	);
 	mainsByFormat.umd = replaceName(
 		pkg['umd:main'] || pkg.unpkg || 'x.umd.js',
 		mainNoExtension,


### PR DESCRIPTION
The old implementation will not allow to use a filename with the extension ".cjs" in the "main" field and does not create a Common JS file with a ".cjs" ending.

If a package.json contains "type":"module"  all files with ".js" will throw an error if they are imported with an `require` function. 

This fix:
* will strip `.cjs` when creating the base name
* switch from default extension `.js` to `.cjs` when `"type":"module"` exists in `package.json`
* update documentation to highlight the problem

This solves #801 