### PR TITLE
Fix/css module types

### DIFF
--- a/.changeset/dirty-islands-fail.md
+++ b/.changeset/dirty-islands-fail.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Ensures ambient type declaration for CSS Modules is included in the published bundle

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Just point the input to a `.ts` file through either the cli or the `source` key 
 
 Microbundle will generally respect your TypeScript config defined in a `tsconfig.json` file with notable exceptions being the "[target](https://www.typescriptlang.org/tsconfig#target)" and "[module](https://www.typescriptlang.org/tsconfig#module)" settings. To ensure your TypeScript configuration matches the configuration that Microbundle uses internally it's strongly recommended that you set `"module": "ESNext"` and `"target": "ESNext"` in your `tsconfig.json`.
 
+If you're using TypeScript with CSS Modules, you will want to set `"include": ["node_modules/microbundle/index.d.ts"]` in your `tsconfig.json` to tell TypeScript how to handle your CSS Module imports.
+
 ### CSS and CSS Modules
 
 Importing CSS files is supported via `import "./foo.css"`. By default, generated CSS output is written to disk. The `--css inline` command line option will inline generated CSS into your bundles as a string, returning the CSS string from the import:

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
 	],
 	"files": [
 		"src",
-		"dist"
+		"dist",
+		"index.d.ts"
 	],
 	"author": "Jason Miller <jason@developit.ca> (http://jasonformat.com)",
 	"license": "MIT",


### PR DESCRIPTION
#768 added an ambient type declaration for CSS Modules, however, this was not included in the list of of files to be published, so it never got to users

I added quick note in the ReadMe for using this, will probably help a few people. 