### PR TITLE
Fix/css filename output

### DIFF
--- a/.changeset/shy-singers-hide.md
+++ b/.changeset/shy-singers-hide.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Ensures JS format is not included in CSS filename output

--- a/src/index.js
+++ b/src/index.js
@@ -457,7 +457,12 @@ function createConfig(options, entry, format, writeMeta) {
 						modules: cssModulesConfig(options),
 						// only write out CSS for the first bundle (avoids pointless extra files):
 						inject: false,
-						extract: options.css !== 'inline',
+						extract:
+							options.css !== 'inline' &&
+							options.output.replace(
+								/(\.(umd|cjs|es|m))?\.(mjs|[tj]sx?)$/,
+								'.css',
+							),
 						minimize: options.compress,
 						sourceMap: options.sourcemap && options.css !== 'inline',
 					}),


### PR DESCRIPTION
Fixes #779

I'd love to do / add some better detection here, but not sure how reasonable it is considering the current state of things. Ideally (in my mind at least) names would be chosen in a way resembling the following order:

- a `".css"` key in `"exports"`
- `"exports": { "./": { default } }`
- `"exports": { "./" }`, if it's a string
- `"exports"`, if it's a string
- `"main"`
- `options.output`

I believe that'd make sense as a set of fallbacks, but the point is that those would be some reasonable items to use as the CSS file name.

However, besides #784 we're not currently using `"exports"` for any detection / output customization so it would feel weird to have CSS be the first thing to utilize that. Certainly happy to add that if it'd make sense to do so!