### PR TITLE
Bugfix: preserve Terser annotations during Babel pass

### DIFF
--- a/.changeset/late-bags-argue.md
+++ b/.changeset/late-bags-argue.md
@@ -1,0 +1,5 @@
+---
+"microbundle": patch
+---
+
+Bugfix: preserve Terser annotations like `/*@__NOINLINE__*/` during Babel pass

--- a/src/lib/babel-custom.js
+++ b/src/lib/babel-custom.js
@@ -196,7 +196,7 @@ export default () => {
 					babelOptions.generatorOpts = {
 						minified: true,
 						compact: true,
-						shouldPrintComment: comment => /[@#]__PURE__/.test(comment),
+						shouldPrintComment: comment => /[@#]__[A-Z]+__/.test(comment),
 					};
 				}
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -2619,6 +2619,54 @@ exports[`fixtures build shebang with microbundle 5`] = `
 "
 `;
 
+exports[`fixtures build terser-annotations with microbundle 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+terser-annotations
+  dist
+    terser-annotations.esm.js
+    terser-annotations.esm.js.map
+    terser-annotations.js
+    terser-annotations.js.map
+    terser-annotations.umd.js
+    terser-annotations.umd.js.map
+  mangle.json
+  package.json
+  src
+    index.js
+
+
+Build \\"terserAnnotations\\" to dist:
+112 B: terser-annotations.js.gz
+86 B: terser-annotations.js.br
+117 B: terser-annotations.esm.js.gz
+88 B: terser-annotations.esm.js.br
+200 B: terser-annotations.umd.js.gz
+159 B: terser-annotations.umd.js.br"
+`;
+
+exports[`fixtures build terser-annotations with microbundle 2`] = `6`;
+
+exports[`fixtures build terser-annotations with microbundle 3`] = `
+"function shouldBePreserved(e,n){return e-n}function main(e,n){return{inlined:function(e,n){return e+n}(e,n),preserved:shouldBePreserved(e,n)}}export default main;
+//# sourceMappingURL=terser-annotations.esm.js.map
+"
+`;
+
+exports[`fixtures build terser-annotations with microbundle 4`] = `
+"function shouldBePreserved(e,r){return e-r}module.exports=function(e,r){return{inlined:function(e,r){return e+r}(e,r),preserved:shouldBePreserved(e,r)}};
+//# sourceMappingURL=terser-annotations.js.map
+"
+`;
+
+exports[`fixtures build terser-annotations with microbundle 5`] = `
+"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e||self).terserAnnotations=n()}(this,function(){function shouldBePreserved(e,n){return e-n}return function(e,n){return{inlined:function(e,n){return e+n}(e,n),preserved:shouldBePreserved(e,n)}}});
+//# sourceMappingURL=terser-annotations.umd.js.map
+"
+`;
+
 exports[`fixtures build ts-custom-declaration with microbundle 1`] = `
 "Used script: microbundle --generateTypes false
 

--- a/test/fixtures/terser-annotations/mangle.json
+++ b/test/fixtures/terser-annotations/mangle.json
@@ -1,0 +1,7 @@
+{
+  "minify": {
+    "mangle": {
+      "keep_fnames": true
+    }
+  }
+}

--- a/test/fixtures/terser-annotations/package.json
+++ b/test/fixtures/terser-annotations/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "terser-annotations"
+}

--- a/test/fixtures/terser-annotations/src/index.js
+++ b/test/fixtures/terser-annotations/src/index.js
@@ -1,0 +1,13 @@
+function shouldBeInlined(a, b) {
+	return a + b;
+}
+
+function shouldBePreserved(a, b) {
+	return a - b;
+}
+
+export default function main(a, b) {
+	const inlined = /*@__INLINE__*/ shouldBeInlined(a, b);
+	const preserved = /*@__NOINLINE__*/ shouldBePreserved(a, b);
+	return { inlined, preserved };
+}


### PR DESCRIPTION
We were stripping out everything except `__PURE__`, but Terser has a number of annotations using that format - these were previously being ignored.