### PR TITLE
Fix: Support booleans in minify options

### DIFF
--- a/.changeset/rude-books-judge.md
+++ b/.changeset/rude-books-judge.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+- Allow the minify options `compress` and `mangle` to be set as booleans

--- a/src/index.js
+++ b/src/index.js
@@ -581,7 +581,9 @@ function createConfig(options, entry, format, writeMeta) {
 									// unsafe_arrows: true,
 									passes: 10,
 								},
-								minifyOptions.compress || {},
+								typeof minifyOptions.compress === 'boolean'
+									? minifyOptions.compress
+									: minifyOptions.compress || {},
 							),
 							format: {
 								// By default, Terser wraps function arguments in extra parens to trigger eager parsing.
@@ -593,7 +595,10 @@ function createConfig(options, entry, format, writeMeta) {
 							module: modern,
 							ecma: modern ? 2017 : 5,
 							toplevel: modern || format === 'cjs' || format === 'es',
-							mangle: Object.assign({}, minifyOptions.mangle || {}),
+							mangle:
+								typeof minifyOptions.mangle === 'boolean'
+									? minifyOptions.mangle
+									: Object.assign({}, minifyOptions.mangle || {}),
 							nameCache,
 						}),
 						nameCache && {

--- a/src/lib/terser.js
+++ b/src/lib/terser.js
@@ -1,5 +1,8 @@
 // Normalize Terser options from microbundle's relaxed JSON format (mutates argument in-place)
 export function normalizeMinifyOptions(minifyOptions) {
+	// ignore normalization if "mangle" is a boolean:
+	if (typeof minifyOptions.mangle === 'boolean') return;
+
 	const mangle = minifyOptions.mangle || (minifyOptions.mangle = {});
 	let properties = mangle.properties;
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1915,6 +1915,54 @@ exports[`fixtures build minify-config with microbundle 5`] = `
 "
 `;
 
+exports[`fixtures build minify-config-boolean with microbundle 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+minify-config-boolean
+  dist
+    minify-config-boolean.esm.js
+    minify-config-boolean.esm.js.map
+    minify-config-boolean.js
+    minify-config-boolean.js.map
+    minify-config-boolean.umd.js
+    minify-config-boolean.umd.js.map
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"minifyConfigBoolean\\" to dist:
+107 B: minify-config-boolean.js.gz
+84 B: minify-config-boolean.js.br
+114 B: minify-config-boolean.esm.js.gz
+90 B: minify-config-boolean.esm.js.br
+216 B: minify-config-boolean.umd.js.gz
+159 B: minify-config-boolean.umd.js.br"
+`;
+
+exports[`fixtures build minify-config-boolean with microbundle 2`] = `6`;
+
+exports[`fixtures build minify-config-boolean with microbundle 3`] = `
+"var two={prop1:1,_prop2:2};function index(){return console.log(two.prop1),console.log(two._prop2),two}export default index;
+//# sourceMappingURL=minify-config-boolean.esm.js.map
+"
+`;
+
+exports[`fixtures build minify-config-boolean with microbundle 4`] = `
+"var two={prop1:1,_prop2:2};module.exports=function(){return console.log(two.prop1),console.log(two._prop2),two};
+//# sourceMappingURL=minify-config-boolean.js.map
+"
+`;
+
+exports[`fixtures build minify-config-boolean with microbundle 5`] = `
+"!function(global,factory){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=factory():\\"function\\"==typeof define&&define.amd?define(factory):(global||self).minifyConfigBoolean=factory()}(this,function(){var two={prop1:1,_prop2:2};return function(){return console.log(two.prop1),console.log(two._prop2),two}});
+//# sourceMappingURL=minify-config-boolean.umd.js.map
+"
+`;
+
 exports[`fixtures build minify-path-config with microbundle 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/minify-config-boolean/package.json
+++ b/test/fixtures/minify-config-boolean/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "minify-config-boolean",
+  "minify": {
+    "compress": true,
+    "mangle": false
+  }
+}

--- a/test/fixtures/minify-config-boolean/src/index.js
+++ b/test/fixtures/minify-config-boolean/src/index.js
@@ -1,0 +1,7 @@
+import { two } from './two';
+
+export default function () {
+	console.log(two.prop1);
+	console.log(two._prop2);
+	return two;
+}

--- a/test/fixtures/minify-config-boolean/src/two.js
+++ b/test/fixtures/minify-config-boolean/src/two.js
@@ -1,0 +1,4 @@
+export const two = {
+	prop1: 1,
+	_prop2: 2,
+};


### PR DESCRIPTION
**Context:** Disabling Terser's mangling completely is only possible by setting `mangle` to `false`, but currently Microbundle replaces any non-object `mangle` option by `{}`.

This PR adds a special condition to allow the minify options `compress` and `mangle` to be set as booleans.