### PR TITLE
feat: Expands generateTypes flag to support TS entries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -518,10 +518,12 @@ function createConfig(options, entry, format, writeMeta) {
 							tsconfigDefaults: {
 								compilerOptions: {
 									sourceMap: options.sourcemap,
-									declaration: true,
+									declaration: emitDeclaration,
 									allowJs: true,
 									emitDeclarationOnly: options.generateTypes && !useTypescript,
-									declarationDir: getDeclarationDir({ options, pkg }),
+									...(emitDeclaration && {
+										declarationDir: getDeclarationDir({ options, pkg }),
+									}),
 									jsx: 'preserve',
 									jsxFactory:
 										// TypeScript fails to resolve Fragments when jsxFactory


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature, expands the `--generateTypes` flag to also support projects with TS entry points.

**Did you add tests for your changes?**

Modified an existing test

**Summary**

Closes #863

The problem with the existing `--generateTypes` behavior is that it is only relevant when used with JS entry points.

`emitDeclaration` is derived from `options.generateTypes` and is only used in the following spot:

https://github.com/developit/microbundle/blob/b1a637486234a2ae784ccf0c512321e2d3efef7c/src/index.js#L510

Which means that when `useTypescript` is truthy, that option holds no power whatsoever. `useTypescript` would be truthy on any project that had TS entry points:

https://github.com/developit/microbundle/blob/b1a637486234a2ae784ccf0c512321e2d3efef7c/src/index.js#L387

To allow projects with TS entry points to disable types from being output, we now simply disable TS's `declaration` compiler option if `options.generateTypes` is set to false.

**Does this PR introduce a breaking change?**

No
