### PR TITLE
Fix: preserve terser annotations regexp

### DIFF
--- a/.changeset/gold-cherries-deliver.md
+++ b/.changeset/gold-cherries-deliver.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Preserve terser annotations in compressed bundle

--- a/src/index.js
+++ b/src/index.js
@@ -589,7 +589,7 @@ function createConfig(options, entry, format, writeMeta) {
 								// By default, Terser wraps function arguments in extra parens to trigger eager parsing.
 								// Whether this is a good idea is way too specific to guess, so we optimize for size by default:
 								wrap_func_args: false,
-								comments: /^\s*([@#]__[A-Z]__\s*$|@cc_on)/,
+								comments: /^\s*([@#]__[A-Z]+__\s*$|@cc_on)/,
 								preserve_annotations: true,
 							},
 							module: modern,

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -165,30 +165,30 @@ async-ts
 
 
 Build \\"asyncTs\\" to dist:
-103 B: async-ts.js.gz
-72 B: async-ts.js.br
-112 B: async-ts.esm.js.gz
-91 B: async-ts.esm.js.br
-200 B: async-ts.umd.js.gz
-156 B: async-ts.umd.js.br"
+117 B: async-ts.js.gz
+91 B: async-ts.js.br
+128 B: async-ts.esm.js.gz
+108 B: async-ts.esm.js.br
+217 B: async-ts.umd.js.gz
+164 B: async-ts.umd.js.br"
 `;
 
 exports[`fixtures build async-ts with microbundle 2`] = `7`;
 
 exports[`fixtures build async-ts with microbundle 3`] = `
-"var o=function(){function o(){}return o.prototype.foo=function(){return Promise.resolve()},o}();export{o as MyClass};
+"var o=/*#__PURE__*/function(){function o(){}return o.prototype.foo=function(){return Promise.resolve()},o}();export{o as MyClass};
 //# sourceMappingURL=async-ts.esm.js.map
 "
 `;
 
 exports[`fixtures build async-ts with microbundle 4`] = `
-"exports.MyClass=function(){function o(){}return o.prototype.foo=function(){return Promise.resolve()},o}();
+"exports.MyClass=/*#__PURE__*/function(){function o(){}return o.prototype.foo=function(){return Promise.resolve()},o}();
 //# sourceMappingURL=async-ts.js.map
 "
 `;
 
 exports[`fixtures build async-ts with microbundle 5`] = `
-"!function(e,o){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?o(exports):\\"function\\"==typeof define&&define.amd?define([\\"exports\\"],o):o((e||self).asyncTs={})}(this,function(e){e.MyClass=function(){function e(){}return e.prototype.foo=function(){return Promise.resolve()},e}()});
+"!function(e,o){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?o(exports):\\"function\\"==typeof define&&define.amd?define([\\"exports\\"],o):o((e||self).asyncTs={})}(this,function(e){e.MyClass=/*#__PURE__*/function(){function e(){}return e.prototype.foo=function(){return Promise.resolve()},e}()});
 //# sourceMappingURL=async-ts.umd.js.map
 "
 `;
@@ -500,12 +500,12 @@ basic-dashed-external
 
 
 Build \\"basicDashedExternal\\" to dist:
-259 B: basic-dashed-external.js.gz
-196 B: basic-dashed-external.js.br
+276 B: basic-dashed-external.js.gz
+212 B: basic-dashed-external.js.br
 214 B: basic-dashed-external.esm.js.gz
 164 B: basic-dashed-external.esm.js.br
-343 B: basic-dashed-external.umd.js.gz
-286 B: basic-dashed-external.umd.js.br"
+357 B: basic-dashed-external.umd.js.gz
+285 B: basic-dashed-external.umd.js.br"
 `;
 
 exports[`fixtures build basic-dashed-external with microbundle 2`] = `6`;
@@ -517,13 +517,13 @@ exports[`fixtures build basic-dashed-external with microbundle 3`] = `
 `;
 
 exports[`fixtures build basic-dashed-external with microbundle 4`] = `
-"var e=require(\\"tiny-glob\\");function r(e){return e&&\\"object\\"==typeof e&&\\"default\\"in e?e:{default:e}}var t=function(){try{var e=arguments;return Promise.resolve([].slice.call(e).reduce(function(e,r){return e+r},0))}catch(e){return Promise.reject(e)}};console.log(r(e).default),module.exports=function(){try{var e=arguments,r=[].slice.call(e);return Promise.resolve(t.apply(void 0,r)).then(function(e){return Promise.resolve(t.apply(void 0,r)).then(function(r){return[e,r]})})}catch(e){return Promise.reject(e)}};
+"var e=require(\\"tiny-glob\\");function r(e){return e&&\\"object\\"==typeof e&&\\"default\\"in e?e:{default:e}}var t=function(){try{var e=arguments;return Promise.resolve([].slice.call(e).reduce(function(e,r){return e+r},0))}catch(e){return Promise.reject(e)}};console.log(/*#__PURE__*/r(e).default),module.exports=function(){try{var e=arguments,r=[].slice.call(e);return Promise.resolve(t.apply(void 0,r)).then(function(e){return Promise.resolve(t.apply(void 0,r)).then(function(r){return[e,r]})})}catch(e){return Promise.reject(e)}};
 //# sourceMappingURL=basic-dashed-external.js.map
 "
 `;
 
 exports[`fixtures build basic-dashed-external with microbundle 5`] = `
-"!function(e,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=t(require(\\"tiny-glob\\")):\\"function\\"==typeof define&&define.amd?define([\\"tiny-glob\\"],t):(e||self).basicDashedExternal=t(e.tinyGlob)}(this,function(e){function t(e){return e&&\\"object\\"==typeof e&&\\"default\\"in e?e:{default:e}}var n=function(){try{var e=arguments;return Promise.resolve([].slice.call(e).reduce(function(e,t){return e+t},0))}catch(e){return Promise.reject(e)}};return console.log(t(e).default),function(){try{var e=arguments,t=[].slice.call(e);return Promise.resolve(n.apply(void 0,t)).then(function(e){return Promise.resolve(n.apply(void 0,t)).then(function(t){return[e,t]})})}catch(e){return Promise.reject(e)}}});
+"!function(e,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=t(require(\\"tiny-glob\\")):\\"function\\"==typeof define&&define.amd?define([\\"tiny-glob\\"],t):(e||self).basicDashedExternal=t(e.tinyGlob)}(this,function(e){function t(e){return e&&\\"object\\"==typeof e&&\\"default\\"in e?e:{default:e}}var n=function(){try{var e=arguments;return Promise.resolve([].slice.call(e).reduce(function(e,t){return e+t},0))}catch(e){return Promise.reject(e)}};return console.log(/*#__PURE__*/t(e).default),function(){try{var e=arguments,t=[].slice.call(e);return Promise.resolve(n.apply(void 0,t)).then(function(e){return Promise.resolve(n.apply(void 0,t)).then(function(t){return[e,t]})})}catch(e){return Promise.reject(e)}}});
 //# sourceMappingURL=basic-dashed-external.umd.js.map
 "
 `;
@@ -928,30 +928,30 @@ basic-ts
 
 
 Build \\"basicLibTs\\" to dist:
-104 B: basic-lib-ts.js.gz
-76 B: basic-lib-ts.js.br
-104 B: basic-lib-ts.esm.js.gz
-82 B: basic-lib-ts.esm.js.br
-186 B: basic-lib-ts.umd.js.gz
-141 B: basic-lib-ts.umd.js.br"
+118 B: basic-lib-ts.js.gz
+94 B: basic-lib-ts.js.br
+118 B: basic-lib-ts.esm.js.gz
+97 B: basic-lib-ts.esm.js.br
+201 B: basic-lib-ts.umd.js.gz
+150 B: basic-lib-ts.umd.js.br"
 `;
 
 exports[`fixtures build basic-ts with microbundle 2`] = `8`;
 
 exports[`fixtures build basic-ts with microbundle 3`] = `
-"var n=new(function(){function n(){}return n.prototype.drive=function(n){return!0},n}());export default n;
+"var n=new(/*#__PURE__*/function(){function n(){}return n.prototype.drive=function(n){return!0},n}());export default n;
 //# sourceMappingURL=basic-lib-ts.esm.js.map
 "
 `;
 
 exports[`fixtures build basic-ts with microbundle 4`] = `
-"var n=new(function(){function n(){}return n.prototype.drive=function(n){return!0},n}());module.exports=n;
+"var n=new(/*#__PURE__*/function(){function n(){}return n.prototype.drive=function(n){return!0},n}());module.exports=n;
 //# sourceMappingURL=basic-lib-ts.js.map
 "
 `;
 
 exports[`fixtures build basic-ts with microbundle 5`] = `
-"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e||self).basicLibTs=n()}(this,function(){return new(function(){function e(){}return e.prototype.drive=function(e){return!0},e}())});
+"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e||self).basicLibTs=n()}(this,function(){return new(/*#__PURE__*/function(){function e(){}return e.prototype.drive=function(e){return!0},e}())});
 //# sourceMappingURL=basic-lib-ts.umd.js.map
 "
 `;
@@ -995,30 +995,31 @@ basic-tsx
 
 
 Build \\"basicLibTsx\\" to dist:
-199 B: basic-lib-tsx.js.gz
-153 B: basic-lib-tsx.js.br
-200 B: basic-lib-tsx.esm.js.gz
-153 B: basic-lib-tsx.esm.js.br
-281 B: basic-lib-tsx.umd.js.gz
-217 B: basic-lib-tsx.umd.js.br"
+213 B: basic-lib-tsx.js.gz
+164 B: basic-lib-tsx.js.br
+218 B: basic-lib-tsx.esm.js.gz
+172 B: basic-lib-tsx.esm.js.br
+298 B: basic-lib-tsx.umd.js.gz
+232 B: basic-lib-tsx.umd.js.br"
 `;
 
 exports[`fixtures build basic-tsx with microbundle 2`] = `7`;
 
 exports[`fixtures build basic-tsx with microbundle 3`] = `
-"var n=function(n,r){return{tag:n,props:r,children:[].slice.call(arguments,2)}},r=function(){function r(){}return r.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"))},r}();export default r;
+"var n=function(n,r){return{tag:n,props:r,children:[].slice.call(arguments,2)}},r=/*#__PURE__*/function(){function r(){}return r.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"))},r}();export default r;
 //# sourceMappingURL=basic-lib-tsx.esm.js.map
 "
 `;
 
 exports[`fixtures build basic-tsx with microbundle 4`] = `
-"var n=function(n,r){return{tag:n,props:r,children:[].slice.call(arguments,2)}};module.exports=function(){function r(){}return r.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"))},r}();
+"var n=function(n,r){return{tag:n,props:r,children:[].slice.call(arguments,2)}};module.exports=/*#__PURE__*/function(){function r(){}return r.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"))},r}();
 //# sourceMappingURL=basic-lib-tsx.js.map
 "
 `;
 
 exports[`fixtures build basic-tsx with microbundle 5`] = `
-"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e||self).basicLibTsx=n()}(this,function(){var e=function(e,n){return{tag:e,props:n,children:[].slice.call(arguments,2)}};return function(){function n(){}return n.prototype.render=function(){return e(\\"div\\",{id:\\"app\\"},e(\\"h1\\",null,\\"Hello, World!\\"),e(\\"p\\",null,\\"A JSX demo.\\"))},n}()});
+"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e||self).basicLibTsx=n()}(this,function(){var e=function(e,n){return{tag:e,props:n,children:[].slice.call(arguments,2)}};/*#__PURE__*/
+return function(){function n(){}return n.prototype.render=function(){return e(\\"div\\",{id:\\"app\\"},e(\\"h1\\",null,\\"Hello, World!\\"),e(\\"p\\",null,\\"A JSX demo.\\"))},n}()});
 //# sourceMappingURL=basic-lib-tsx.umd.js.map
 "
 `;
@@ -1100,30 +1101,30 @@ class-decorators-ts
 
 
 Build \\"classDecoratorsTs\\" to dist:
-333 B: class-decorators-ts.js.gz
-276 B: class-decorators-ts.js.br
-333 B: class-decorators-ts.esm.js.gz
-278 B: class-decorators-ts.esm.js.br
-400 B: class-decorators-ts.umd.js.gz
-341 B: class-decorators-ts.umd.js.br"
+348 B: class-decorators-ts.js.gz
+288 B: class-decorators-ts.js.br
+348 B: class-decorators-ts.esm.js.gz
+288 B: class-decorators-ts.esm.js.br
+415 B: class-decorators-ts.umd.js.gz
+353 B: class-decorators-ts.umd.js.br"
 `;
 
 exports[`fixtures build class-decorators-ts with microbundle 2`] = `7`;
 
 exports[`fixtures build class-decorators-ts with microbundle 3`] = `
-"var e=function(){function e(e){this.greeting=e}return e.prototype.greet=function(){return\\"Hello, \\"+this.greeting},e}(),t=new(e=function(e,t,r,n){var o,c=arguments.length,l=c<3?t:null===n?n=Object.getOwnPropertyDescriptor(t,r):n;if(\\"object\\"==typeof Reflect&&\\"function\\"==typeof Reflect.decorate)l=Reflect.decorate(e,t,r,n);else for(var f=e.length-1;f>=0;f--)(o=e[f])&&(l=(c<3?o(l):c>3?o(t,r,l):o(t,r))||l);return c>3&&l&&Object.defineProperty(t,r,l),l}([function(e){Object.seal(e),Object.seal(e.prototype)}],e))(\\"Hello World\\");export default t;
+"var e=/*#__PURE__*/function(){function e(e){this.greeting=e}return e.prototype.greet=function(){return\\"Hello, \\"+this.greeting},e}(),t=new(e=function(e,t,r,n){var o,c=arguments.length,l=c<3?t:null===n?n=Object.getOwnPropertyDescriptor(t,r):n;if(\\"object\\"==typeof Reflect&&\\"function\\"==typeof Reflect.decorate)l=Reflect.decorate(e,t,r,n);else for(var f=e.length-1;f>=0;f--)(o=e[f])&&(l=(c<3?o(l):c>3?o(t,r,l):o(t,r))||l);return c>3&&l&&Object.defineProperty(t,r,l),l}([function(e){Object.seal(e),Object.seal(e.prototype)}],e))(\\"Hello World\\");export default t;
 //# sourceMappingURL=class-decorators-ts.esm.js.map
 "
 `;
 
 exports[`fixtures build class-decorators-ts with microbundle 4`] = `
-"var e=function(){function e(e){this.greeting=e}return e.prototype.greet=function(){return\\"Hello, \\"+this.greeting},e}(),t=new(e=function(e,t,r,o){var n,c=arguments.length,l=c<3?t:null===o?o=Object.getOwnPropertyDescriptor(t,r):o;if(\\"object\\"==typeof Reflect&&\\"function\\"==typeof Reflect.decorate)l=Reflect.decorate(e,t,r,o);else for(var f=e.length-1;f>=0;f--)(n=e[f])&&(l=(c<3?n(l):c>3?n(t,r,l):n(t,r))||l);return c>3&&l&&Object.defineProperty(t,r,l),l}([function(e){Object.seal(e),Object.seal(e.prototype)}],e))(\\"Hello World\\");module.exports=t;
+"var e=/*#__PURE__*/function(){function e(e){this.greeting=e}return e.prototype.greet=function(){return\\"Hello, \\"+this.greeting},e}(),t=new(e=function(e,t,r,o){var n,c=arguments.length,l=c<3?t:null===o?o=Object.getOwnPropertyDescriptor(t,r):o;if(\\"object\\"==typeof Reflect&&\\"function\\"==typeof Reflect.decorate)l=Reflect.decorate(e,t,r,o);else for(var f=e.length-1;f>=0;f--)(n=e[f])&&(l=(c<3?n(l):c>3?n(t,r,l):n(t,r))||l);return c>3&&l&&Object.defineProperty(t,r,l),l}([function(e){Object.seal(e),Object.seal(e.prototype)}],e))(\\"Hello World\\");module.exports=t;
 //# sourceMappingURL=class-decorators-ts.js.map
 "
 `;
 
 exports[`fixtures build class-decorators-ts with microbundle 5`] = `
-"!function(e,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define(t):(e||self).classDecoratorsTs=t()}(this,function(){var e=function(){function e(e){this.greeting=e}return e.prototype.greet=function(){return\\"Hello, \\"+this.greeting},e}();return new(e=function(e,t,o,n){var r,f=arguments.length,i=f<3?t:null===n?n=Object.getOwnPropertyDescriptor(t,o):n;if(\\"object\\"==typeof Reflect&&\\"function\\"==typeof Reflect.decorate)i=Reflect.decorate(e,t,o,n);else for(var c=e.length-1;c>=0;c--)(r=e[c])&&(i=(f<3?r(i):f>3?r(t,o,i):r(t,o))||i);return f>3&&i&&Object.defineProperty(t,o,i),i}([function(e){Object.seal(e),Object.seal(e.prototype)}],e))(\\"Hello World\\")});
+"!function(e,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define(t):(e||self).classDecoratorsTs=t()}(this,function(){var e=/*#__PURE__*/function(){function e(e){this.greeting=e}return e.prototype.greet=function(){return\\"Hello, \\"+this.greeting},e}();return new(e=function(e,t,o,n){var r,f=arguments.length,i=f<3?t:null===n?n=Object.getOwnPropertyDescriptor(t,o):n;if(\\"object\\"==typeof Reflect&&\\"function\\"==typeof Reflect.decorate)i=Reflect.decorate(e,t,o,n);else for(var c=e.length-1;c>=0;c--)(r=e[c])&&(i=(f<3?r(i):f>3?r(t,o,i):r(t,o))||i);return f>3&&i&&Object.defineProperty(t,o,i),i}([function(e){Object.seal(e),Object.seal(e.prototype)}],e))(\\"Hello World\\")});
 //# sourceMappingURL=class-decorators-ts.umd.js.map
 "
 `;
@@ -1646,30 +1647,30 @@ esnext-ts
 
 
 Build \\"esnextTs\\" to dist:
-989 B: esnext-ts.js.gz
-883 B: esnext-ts.js.br
-990 B: esnext-ts.esm.js.gz
-881 B: esnext-ts.esm.js.br
-1050 B: esnext-ts.umd.js.gz
-932 B: esnext-ts.umd.js.br"
+1007 B: esnext-ts.js.gz
+898 B: esnext-ts.js.br
+1008 B: esnext-ts.esm.js.gz
+898 B: esnext-ts.esm.js.br
+1068 B: esnext-ts.umd.js.gz
+950 B: esnext-ts.umd.js.br"
 `;
 
 exports[`fixtures build esnext-ts with microbundle 2`] = `7`;
 
 exports[`fixtures build esnext-ts with microbundle 3`] = `
-"function n(t,e,i){if(!t.s){if(i instanceof r){if(!i.s)return void(i.o=n.bind(null,t,e));1&e&&(e=i.s),i=i.v}if(i&&i.then)return void i.then(n.bind(null,t,e),n.bind(null,t,2));t.s=e,t.v=i;var o=t.o;o&&o(t)}}var t=function(){try{var t,o,u,f,h=[],c=!0,v=!1,a=i(function(){return function(i,f){try{var v=function(){t=function(n){var t;if(\\"undefined\\"!=typeof Symbol){if(Symbol.asyncIterator&&null!=(t=n[Symbol.asyncIterator]))return t.call(n);if(Symbol.iterator&&null!=(t=n[Symbol.iterator]))return t.call(n)}throw new TypeError(\\"Object is not async iterable\\")}([1,2]);var i=function(t,i,o){for(var u;;){var f=t();if(e(f)&&(f=f.v),!f)return h;if(f.then){u=0;break}var h=o();if(h&&h.then){if(!e(h)){u=1;break}h=h.s}if(i){var c=i();if(c&&c.then&&!e(c)){u=2;break}}}var v=new r,a=n.bind(null,v,2);return(0===u?f.then(s):1===u?h.then(l):c.then(d)).then(void 0,a),v;function l(r){h=r;do{if(i&&(c=i())&&c.then&&!e(c))return void c.then(d).then(void 0,a);if(!(f=t())||e(f)&&!f.v)return void n(v,1,h);if(f.then)return void f.then(s).then(void 0,a);e(h=o())&&(h=h.v)}while(!h||!h.then);h.then(l).then(void 0,a)}function s(t){t?(h=o())&&h.then?h.then(l).then(void 0,a):l(h):n(v,1,h)}function d(){(f=t())?f.then?f.then(s).then(void 0,a):s(f):n(v,1,h)}}(function(){return!!Promise.resolve(t.next()).then(function(n){return c=o.done,o=n,Promise.resolve(o.value).then(function(n){return u=n,!c})})},function(){return!!(c=!0)},function(){h.push(u)});if(i&&i.then)return i.then(function(){})}()}catch(n){return f(n)}return v&&v.then?v.then(void 0,f):v}(0,function(n){v=!0,f=n})},function(n,r){function e(t){if(n)throw r;return r}var o=i(function(){var n=function(){if(!c&&null!=t.return)return Promise.resolve(t.return()).then(function(){})}();if(n&&n.then)return n.then(function(){})},function(n,t){if(v)throw f;if(n)throw t;return t});return o&&o.then?o.then(e):e()});return Promise.resolve(a&&a.then?a.then(function(n){return h}):h)}catch(n){return Promise.reject(n)}},r=function(){function t(){}return t.prototype.then=function(r,e){var i=new t,o=this.s;if(o){var u=1&o?r:e;if(u){try{n(i,1,u(this.v))}catch(t){n(i,2,t)}return i}return this}return this.o=function(t){try{var o=t.v;1&t.s?n(i,1,r?r(o):o):e?n(i,1,e(o)):n(i,2,o)}catch(t){n(i,2,t)}},i},t}();function e(n){return n instanceof r&&1&n.s}function i(n,t){try{var r=n()}catch(n){return t(!0,n)}return r&&r.then?r.then(t.bind(null,!1),t.bind(null,!0)):t(!1,r)}t().then(console.log);export default t;
+"function n(t,e,i){if(!t.s){if(i instanceof r){if(!i.s)return void(i.o=n.bind(null,t,e));1&e&&(e=i.s),i=i.v}if(i&&i.then)return void i.then(n.bind(null,t,e),n.bind(null,t,2));t.s=e,t.v=i;var o=t.o;o&&o(t)}}var t=function(){try{var t,o,u,f,h=[],c=!0,v=!1,a=i(function(){return function(i,f){try{var v=function(){t=function(n){var t;if(\\"undefined\\"!=typeof Symbol){if(Symbol.asyncIterator&&null!=(t=n[Symbol.asyncIterator]))return t.call(n);if(Symbol.iterator&&null!=(t=n[Symbol.iterator]))return t.call(n)}throw new TypeError(\\"Object is not async iterable\\")}([1,2]);var i=function(t,i,o){for(var u;;){var f=t();if(e(f)&&(f=f.v),!f)return h;if(f.then){u=0;break}var h=o();if(h&&h.then){if(!e(h)){u=1;break}h=h.s}if(i){var c=i();if(c&&c.then&&!e(c)){u=2;break}}}var v=new r,a=n.bind(null,v,2);return(0===u?f.then(s):1===u?h.then(l):c.then(d)).then(void 0,a),v;function l(r){h=r;do{if(i&&(c=i())&&c.then&&!e(c))return void c.then(d).then(void 0,a);if(!(f=t())||e(f)&&!f.v)return void n(v,1,h);if(f.then)return void f.then(s).then(void 0,a);e(h=o())&&(h=h.v)}while(!h||!h.then);h.then(l).then(void 0,a)}function s(t){t?(h=o())&&h.then?h.then(l).then(void 0,a):l(h):n(v,1,h)}function d(){(f=t())?f.then?f.then(s).then(void 0,a):s(f):n(v,1,h)}}(function(){return!!Promise.resolve(t.next()).then(function(n){return c=o.done,o=n,Promise.resolve(o.value).then(function(n){return u=n,!c})})},function(){return!!(c=!0)},function(){h.push(u)});if(i&&i.then)return i.then(function(){})}()}catch(n){return f(n)}return v&&v.then?v.then(void 0,f):v}(0,function(n){v=!0,f=n})},function(n,r){function e(t){if(n)throw r;return r}var o=i(function(){var n=function(){if(!c&&null!=t.return)return Promise.resolve(t.return()).then(function(){})}();if(n&&n.then)return n.then(function(){})},function(n,t){if(v)throw f;if(n)throw t;return t});return o&&o.then?o.then(e):e()});return Promise.resolve(a&&a.then?a.then(function(n){return h}):h)}catch(n){return Promise.reject(n)}},r=/*#__PURE__*/function(){function t(){}return t.prototype.then=function(r,e){var i=new t,o=this.s;if(o){var u=1&o?r:e;if(u){try{n(i,1,u(this.v))}catch(t){n(i,2,t)}return i}return this}return this.o=function(t){try{var o=t.v;1&t.s?n(i,1,r?r(o):o):e?n(i,1,e(o)):n(i,2,o)}catch(t){n(i,2,t)}},i},t}();function e(n){return n instanceof r&&1&n.s}function i(n,t){try{var r=n()}catch(n){return t(!0,n)}return r&&r.then?r.then(t.bind(null,!1),t.bind(null,!0)):t(!1,r)}t().then(console.log);export default t;
 //# sourceMappingURL=esnext-ts.esm.js.map
 "
 `;
 
 exports[`fixtures build esnext-ts with microbundle 4`] = `
-"function n(t,e,i){if(!t.s){if(i instanceof r){if(!i.s)return void(i.o=n.bind(null,t,e));1&e&&(e=i.s),i=i.v}if(i&&i.then)return void i.then(n.bind(null,t,e),n.bind(null,t,2));t.s=e,t.v=i;var o=t.o;o&&o(t)}}var t=function(){try{var t,o,u,f,h=[],c=!0,v=!1,a=i(function(){return function(i,f){try{var v=function(){t=function(n){var t;if(\\"undefined\\"!=typeof Symbol){if(Symbol.asyncIterator&&null!=(t=n[Symbol.asyncIterator]))return t.call(n);if(Symbol.iterator&&null!=(t=n[Symbol.iterator]))return t.call(n)}throw new TypeError(\\"Object is not async iterable\\")}([1,2]);var i=function(t,i,o){for(var u;;){var f=t();if(e(f)&&(f=f.v),!f)return h;if(f.then){u=0;break}var h=o();if(h&&h.then){if(!e(h)){u=1;break}h=h.s}if(i){var c=i();if(c&&c.then&&!e(c)){u=2;break}}}var v=new r,a=n.bind(null,v,2);return(0===u?f.then(s):1===u?h.then(l):c.then(d)).then(void 0,a),v;function l(r){h=r;do{if(i&&(c=i())&&c.then&&!e(c))return void c.then(d).then(void 0,a);if(!(f=t())||e(f)&&!f.v)return void n(v,1,h);if(f.then)return void f.then(s).then(void 0,a);e(h=o())&&(h=h.v)}while(!h||!h.then);h.then(l).then(void 0,a)}function s(t){t?(h=o())&&h.then?h.then(l).then(void 0,a):l(h):n(v,1,h)}function d(){(f=t())?f.then?f.then(s).then(void 0,a):s(f):n(v,1,h)}}(function(){return!!Promise.resolve(t.next()).then(function(n){return c=o.done,o=n,Promise.resolve(o.value).then(function(n){return u=n,!c})})},function(){return!!(c=!0)},function(){h.push(u)});if(i&&i.then)return i.then(function(){})}()}catch(n){return f(n)}return v&&v.then?v.then(void 0,f):v}(0,function(n){v=!0,f=n})},function(n,r){function e(t){if(n)throw r;return r}var o=i(function(){var n=function(){if(!c&&null!=t.return)return Promise.resolve(t.return()).then(function(){})}();if(n&&n.then)return n.then(function(){})},function(n,t){if(v)throw f;if(n)throw t;return t});return o&&o.then?o.then(e):e()});return Promise.resolve(a&&a.then?a.then(function(n){return h}):h)}catch(n){return Promise.reject(n)}},r=function(){function t(){}return t.prototype.then=function(r,e){var i=new t,o=this.s;if(o){var u=1&o?r:e;if(u){try{n(i,1,u(this.v))}catch(t){n(i,2,t)}return i}return this}return this.o=function(t){try{var o=t.v;1&t.s?n(i,1,r?r(o):o):e?n(i,1,e(o)):n(i,2,o)}catch(t){n(i,2,t)}},i},t}();function e(n){return n instanceof r&&1&n.s}function i(n,t){try{var r=n()}catch(n){return t(!0,n)}return r&&r.then?r.then(t.bind(null,!1),t.bind(null,!0)):t(!1,r)}t().then(console.log),module.exports=t;
+"function n(t,e,i){if(!t.s){if(i instanceof r){if(!i.s)return void(i.o=n.bind(null,t,e));1&e&&(e=i.s),i=i.v}if(i&&i.then)return void i.then(n.bind(null,t,e),n.bind(null,t,2));t.s=e,t.v=i;var o=t.o;o&&o(t)}}var t=function(){try{var t,o,u,f,h=[],c=!0,v=!1,a=i(function(){return function(i,f){try{var v=function(){t=function(n){var t;if(\\"undefined\\"!=typeof Symbol){if(Symbol.asyncIterator&&null!=(t=n[Symbol.asyncIterator]))return t.call(n);if(Symbol.iterator&&null!=(t=n[Symbol.iterator]))return t.call(n)}throw new TypeError(\\"Object is not async iterable\\")}([1,2]);var i=function(t,i,o){for(var u;;){var f=t();if(e(f)&&(f=f.v),!f)return h;if(f.then){u=0;break}var h=o();if(h&&h.then){if(!e(h)){u=1;break}h=h.s}if(i){var c=i();if(c&&c.then&&!e(c)){u=2;break}}}var v=new r,a=n.bind(null,v,2);return(0===u?f.then(s):1===u?h.then(l):c.then(d)).then(void 0,a),v;function l(r){h=r;do{if(i&&(c=i())&&c.then&&!e(c))return void c.then(d).then(void 0,a);if(!(f=t())||e(f)&&!f.v)return void n(v,1,h);if(f.then)return void f.then(s).then(void 0,a);e(h=o())&&(h=h.v)}while(!h||!h.then);h.then(l).then(void 0,a)}function s(t){t?(h=o())&&h.then?h.then(l).then(void 0,a):l(h):n(v,1,h)}function d(){(f=t())?f.then?f.then(s).then(void 0,a):s(f):n(v,1,h)}}(function(){return!!Promise.resolve(t.next()).then(function(n){return c=o.done,o=n,Promise.resolve(o.value).then(function(n){return u=n,!c})})},function(){return!!(c=!0)},function(){h.push(u)});if(i&&i.then)return i.then(function(){})}()}catch(n){return f(n)}return v&&v.then?v.then(void 0,f):v}(0,function(n){v=!0,f=n})},function(n,r){function e(t){if(n)throw r;return r}var o=i(function(){var n=function(){if(!c&&null!=t.return)return Promise.resolve(t.return()).then(function(){})}();if(n&&n.then)return n.then(function(){})},function(n,t){if(v)throw f;if(n)throw t;return t});return o&&o.then?o.then(e):e()});return Promise.resolve(a&&a.then?a.then(function(n){return h}):h)}catch(n){return Promise.reject(n)}},r=/*#__PURE__*/function(){function t(){}return t.prototype.then=function(r,e){var i=new t,o=this.s;if(o){var u=1&o?r:e;if(u){try{n(i,1,u(this.v))}catch(t){n(i,2,t)}return i}return this}return this.o=function(t){try{var o=t.v;1&t.s?n(i,1,r?r(o):o):e?n(i,1,e(o)):n(i,2,o)}catch(t){n(i,2,t)}},i},t}();function e(n){return n instanceof r&&1&n.s}function i(n,t){try{var r=n()}catch(n){return t(!0,n)}return r&&r.then?r.then(t.bind(null,!1),t.bind(null,!0)):t(!1,r)}t().then(console.log),module.exports=t;
 //# sourceMappingURL=esnext-ts.js.map
 "
 `;
 
 exports[`fixtures build esnext-ts with microbundle 5`] = `
-"!function(n,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define(t):(n||self).esnextTs=t()}(this,function(){function n(t,r,i){if(!t.s){if(i instanceof e){if(!i.s)return void(i.o=n.bind(null,t,r));1&r&&(r=i.s),i=i.v}if(i&&i.then)return void i.then(n.bind(null,t,r),n.bind(null,t,2));t.s=r,t.v=i;var o=t.o;o&&o(t)}}var t=function(){try{var t,o,u,f,h=[],c=!0,l=!1,a=i(function(){return function(i,f){try{var l=function(){t=function(n){var t;if(\\"undefined\\"!=typeof Symbol){if(Symbol.asyncIterator&&null!=(t=n[Symbol.asyncIterator]))return t.call(n);if(Symbol.iterator&&null!=(t=n[Symbol.iterator]))return t.call(n)}throw new TypeError(\\"Object is not async iterable\\")}([1,2]);var i=function(t,i,o){for(var u;;){var f=t();if(r(f)&&(f=f.v),!f)return h;if(f.then){u=0;break}var h=o();if(h&&h.then){if(!r(h)){u=1;break}h=h.s}if(i){var c=i();if(c&&c.then&&!r(c)){u=2;break}}}var l=new e,a=n.bind(null,l,2);return(0===u?f.then(s):1===u?h.then(v):c.then(d)).then(void 0,a),l;function v(e){h=e;do{if(i&&(c=i())&&c.then&&!r(c))return void c.then(d).then(void 0,a);if(!(f=t())||r(f)&&!f.v)return void n(l,1,h);if(f.then)return void f.then(s).then(void 0,a);r(h=o())&&(h=h.v)}while(!h||!h.then);h.then(v).then(void 0,a)}function s(t){t?(h=o())&&h.then?h.then(v).then(void 0,a):v(h):n(l,1,h)}function d(){(f=t())?f.then?f.then(s).then(void 0,a):s(f):n(l,1,h)}}(function(){return!!Promise.resolve(t.next()).then(function(n){return c=o.done,o=n,Promise.resolve(o.value).then(function(n){return u=n,!c})})},function(){return!!(c=!0)},function(){h.push(u)});if(i&&i.then)return i.then(function(){})}()}catch(n){return f(n)}return l&&l.then?l.then(void 0,f):l}(0,function(n){l=!0,f=n})},function(n,e){function r(t){if(n)throw e;return e}var o=i(function(){var n=function(){if(!c&&null!=t.return)return Promise.resolve(t.return()).then(function(){})}();if(n&&n.then)return n.then(function(){})},function(n,t){if(l)throw f;if(n)throw t;return t});return o&&o.then?o.then(r):r()});return Promise.resolve(a&&a.then?a.then(function(n){return h}):h)}catch(n){return Promise.reject(n)}},e=function(){function t(){}return t.prototype.then=function(e,r){var i=new t,o=this.s;if(o){var u=1&o?e:r;if(u){try{n(i,1,u(this.v))}catch(t){n(i,2,t)}return i}return this}return this.o=function(t){try{var o=t.v;1&t.s?n(i,1,e?e(o):o):r?n(i,1,r(o)):n(i,2,o)}catch(t){n(i,2,t)}},i},t}();function r(n){return n instanceof e&&1&n.s}function i(n,t){try{var e=n()}catch(n){return t(!0,n)}return e&&e.then?e.then(t.bind(null,!1),t.bind(null,!0)):t(!1,e)}return t().then(console.log),t});
+"!function(n,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define(t):(n||self).esnextTs=t()}(this,function(){function n(t,r,i){if(!t.s){if(i instanceof e){if(!i.s)return void(i.o=n.bind(null,t,r));1&r&&(r=i.s),i=i.v}if(i&&i.then)return void i.then(n.bind(null,t,r),n.bind(null,t,2));t.s=r,t.v=i;var o=t.o;o&&o(t)}}var t=function(){try{var t,o,u,f,h=[],c=!0,l=!1,a=i(function(){return function(i,f){try{var l=function(){t=function(n){var t;if(\\"undefined\\"!=typeof Symbol){if(Symbol.asyncIterator&&null!=(t=n[Symbol.asyncIterator]))return t.call(n);if(Symbol.iterator&&null!=(t=n[Symbol.iterator]))return t.call(n)}throw new TypeError(\\"Object is not async iterable\\")}([1,2]);var i=function(t,i,o){for(var u;;){var f=t();if(r(f)&&(f=f.v),!f)return h;if(f.then){u=0;break}var h=o();if(h&&h.then){if(!r(h)){u=1;break}h=h.s}if(i){var c=i();if(c&&c.then&&!r(c)){u=2;break}}}var l=new e,a=n.bind(null,l,2);return(0===u?f.then(s):1===u?h.then(v):c.then(d)).then(void 0,a),l;function v(e){h=e;do{if(i&&(c=i())&&c.then&&!r(c))return void c.then(d).then(void 0,a);if(!(f=t())||r(f)&&!f.v)return void n(l,1,h);if(f.then)return void f.then(s).then(void 0,a);r(h=o())&&(h=h.v)}while(!h||!h.then);h.then(v).then(void 0,a)}function s(t){t?(h=o())&&h.then?h.then(v).then(void 0,a):v(h):n(l,1,h)}function d(){(f=t())?f.then?f.then(s).then(void 0,a):s(f):n(l,1,h)}}(function(){return!!Promise.resolve(t.next()).then(function(n){return c=o.done,o=n,Promise.resolve(o.value).then(function(n){return u=n,!c})})},function(){return!!(c=!0)},function(){h.push(u)});if(i&&i.then)return i.then(function(){})}()}catch(n){return f(n)}return l&&l.then?l.then(void 0,f):l}(0,function(n){l=!0,f=n})},function(n,e){function r(t){if(n)throw e;return e}var o=i(function(){var n=function(){if(!c&&null!=t.return)return Promise.resolve(t.return()).then(function(){})}();if(n&&n.then)return n.then(function(){})},function(n,t){if(l)throw f;if(n)throw t;return t});return o&&o.then?o.then(r):r()});return Promise.resolve(a&&a.then?a.then(function(n){return h}):h)}catch(n){return Promise.reject(n)}},e=/*#__PURE__*/function(){function t(){}return t.prototype.then=function(e,r){var i=new t,o=this.s;if(o){var u=1&o?e:r;if(u){try{n(i,1,u(this.v))}catch(t){n(i,2,t)}return i}return this}return this.o=function(t){try{var o=t.v;1&t.s?n(i,1,e?e(o):o):r?n(i,1,r(o)):n(i,2,o)}catch(t){n(i,2,t)}},i},t}();function r(n){return n instanceof e&&1&n.s}function i(n,t){try{var e=n()}catch(n){return t(!0,n)}return e&&e.then?e.then(t.bind(null,!1),t.bind(null,!0)):t(!1,e)}return t().then(console.log),t});
 //# sourceMappingURL=esnext-ts.umd.js.map
 "
 `;
@@ -1742,30 +1743,31 @@ jsx
 
 
 Build \\"jsx\\" to dist:
-221 B: jsx.js.gz
-179 B: jsx.js.br
-223 B: jsx.esm.js.gz
-193 B: jsx.esm.js.br
-297 B: jsx.umd.js.gz
-236 B: jsx.umd.js.br"
+239 B: jsx.js.gz
+195 B: jsx.js.br
+237 B: jsx.esm.js.gz
+201 B: jsx.esm.js.br
+313 B: jsx.umd.js.gz
+248 B: jsx.umd.js.br"
 `;
 
 exports[`fixtures build jsx with microbundle 2`] = `6`;
 
 exports[`fixtures build jsx with microbundle 3`] = `
-"var n=function(n,r){return{tag:n,props:r,children:[].slice.call(arguments,2)}},r=function(n){return n.children},l=function(){function l(){}return l.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"),n(r,null,n(\\"p\\",null,\\"Test fragment\\")))},l}();export default l;
+"var n=function(n,r){return{tag:n,props:r,children:[].slice.call(arguments,2)}},r=function(n){return n.children},l=/*#__PURE__*/function(){function l(){}return l.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"),n(r,null,n(\\"p\\",null,\\"Test fragment\\")))},l}();export default l;
 //# sourceMappingURL=jsx.esm.js.map
 "
 `;
 
 exports[`fixtures build jsx with microbundle 4`] = `
-"var n=function(n,r){return{tag:n,props:r,children:[].slice.call(arguments,2)}},r=function(n){return n.children};module.exports=function(){function l(){}return l.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"),n(r,null,n(\\"p\\",null,\\"Test fragment\\")))},l}();
+"var n=function(n,r){return{tag:n,props:r,children:[].slice.call(arguments,2)}},r=function(n){return n.children};module.exports=/*#__PURE__*/function(){function l(){}return l.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"),n(r,null,n(\\"p\\",null,\\"Test fragment\\")))},l}();
 //# sourceMappingURL=jsx.js.map
 "
 `;
 
 exports[`fixtures build jsx with microbundle 5`] = `
-"!function(n,e){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=e():\\"function\\"==typeof define&&define.amd?define(e):(n||self).jsx=e()}(this,function(){var n=function(n,e){return{tag:n,props:e,children:[].slice.call(arguments,2)}},e=function(n){return n.children};return function(){function t(){}return t.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"),n(e,null,n(\\"p\\",null,\\"Test fragment\\")))},t}()});
+"!function(n,e){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=e():\\"function\\"==typeof define&&define.amd?define(e):(n||self).jsx=e()}(this,function(){var n=function(n,e){return{tag:n,props:e,children:[].slice.call(arguments,2)}},e=function(n){return n.children};/*#__PURE__*/
+return function(){function t(){}return t.prototype.render=function(){return n(\\"div\\",{id:\\"app\\"},n(\\"h1\\",null,\\"Hello, World!\\"),n(\\"p\\",null,\\"A JSX demo.\\"),n(e,null,n(\\"p\\",null,\\"Test fragment\\")))},t}()});
 //# sourceMappingURL=jsx.umd.js.map
 "
 `;
@@ -2109,26 +2111,26 @@ modern-generators
 
 
 Build \\"modernGenerators\\" to dist:
-234 B: modern-generators.js.gz
-207 B: modern-generators.js.br
+248 B: modern-generators.js.gz
+201 B: modern-generators.js.br
 118 B: modern-generators.modern.js.gz
 99 B: modern-generators.modern.js.br
-233 B: modern-generators.esm.js.gz
-191 B: modern-generators.esm.js.br
-310 B: modern-generators.umd.js.gz
-257 B: modern-generators.umd.js.br"
+247 B: modern-generators.esm.js.gz
+218 B: modern-generators.esm.js.br
+326 B: modern-generators.umd.js.gz
+267 B: modern-generators.umd.js.br"
 `;
 
 exports[`fixtures build modern-generators with microbundle 2`] = `8`;
 
 exports[`fixtures build modern-generators with microbundle 3`] = `
-"var e=regeneratorRuntime.mark(r);function r(){var r;return regeneratorRuntime.wrap(function(e){for(;;)switch(e.prev=e.next){case 0:r=0;case 1:return e.next=4,r++;case 4:e.next=1;break;case 6:case\\"end\\":return e.stop()}},e)}export default function(){try{var e=r();return Promise.resolve([e.next().value,e.next().value])}catch(e){return Promise.reject(e)}}
+"var e=/*#__PURE__*/regeneratorRuntime.mark(r);function r(){var r;return regeneratorRuntime.wrap(function(e){for(;;)switch(e.prev=e.next){case 0:r=0;case 1:return e.next=4,r++;case 4:e.next=1;break;case 6:case\\"end\\":return e.stop()}},e)}export default function(){try{var e=r();return Promise.resolve([e.next().value,e.next().value])}catch(e){return Promise.reject(e)}}
 //# sourceMappingURL=modern-generators.esm.js.map
 "
 `;
 
 exports[`fixtures build modern-generators with microbundle 4`] = `
-"var e=regeneratorRuntime.mark(r);function r(){var r;return regeneratorRuntime.wrap(function(e){for(;;)switch(e.prev=e.next){case 0:r=0;case 1:return e.next=4,r++;case 4:e.next=1;break;case 6:case\\"end\\":return e.stop()}},e)}module.exports=function(){try{var e=r();return Promise.resolve([e.next().value,e.next().value])}catch(e){return Promise.reject(e)}};
+"var e=/*#__PURE__*/regeneratorRuntime.mark(r);function r(){var r;return regeneratorRuntime.wrap(function(e){for(;;)switch(e.prev=e.next){case 0:r=0;case 1:return e.next=4,r++;case 4:e.next=1;break;case 6:case\\"end\\":return e.stop()}},e)}module.exports=function(){try{var e=r();return Promise.resolve([e.next().value,e.next().value])}catch(e){return Promise.reject(e)}};
 //# sourceMappingURL=modern-generators.js.map
 "
 `;
@@ -2140,7 +2142,7 @@ exports[`fixtures build modern-generators with microbundle 5`] = `
 `;
 
 exports[`fixtures build modern-generators with microbundle 6`] = `
-"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e||self).modernGenerators=n()}(this,function(){var e=regeneratorRuntime.mark(n);function n(){var n;return regeneratorRuntime.wrap(function(e){for(;;)switch(e.prev=e.next){case 0:n=0;case 1:return e.next=4,n++;case 4:e.next=1;break;case 6:case\\"end\\":return e.stop()}},e)}return function(){try{var e=n();return Promise.resolve([e.next().value,e.next().value])}catch(e){return Promise.reject(e)}}});
+"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e||self).modernGenerators=n()}(this,function(){var e=/*#__PURE__*/regeneratorRuntime.mark(n);function n(){var n;return regeneratorRuntime.wrap(function(e){for(;;)switch(e.prev=e.next){case 0:n=0;case 1:return e.next=4,n++;case 4:e.next=1;break;case 6:case\\"end\\":return e.stop()}},e)}return function(){try{var e=n();return Promise.resolve([e.next().value,e.next().value])}catch(e){return Promise.reject(e)}}});
 //# sourceMappingURL=modern-generators.umd.js.map
 "
 `;
@@ -2687,30 +2689,30 @@ terser-annotations
 
 
 Build \\"terserAnnotations\\" to dist:
-112 B: terser-annotations.js.gz
-86 B: terser-annotations.js.br
-117 B: terser-annotations.esm.js.gz
-88 B: terser-annotations.esm.js.br
-200 B: terser-annotations.umd.js.gz
-159 B: terser-annotations.umd.js.br"
+133 B: terser-annotations.js.gz
+104 B: terser-annotations.js.br
+138 B: terser-annotations.esm.js.gz
+97 B: terser-annotations.esm.js.br
+224 B: terser-annotations.umd.js.gz
+169 B: terser-annotations.umd.js.br"
 `;
 
 exports[`fixtures build terser-annotations with microbundle 2`] = `6`;
 
 exports[`fixtures build terser-annotations with microbundle 3`] = `
-"function shouldBePreserved(e,n){return e-n}function main(e,n){return{inlined:function(e,n){return e+n}(e,n),preserved:shouldBePreserved(e,n)}}export default main;
+"function shouldBePreserved(e,n){return e-n}function main(e,n){return{inlined:/*@__INLINE__*/function(e,n){return e+n}(e,n),preserved:/*@__NOINLINE__*/shouldBePreserved(e,n)}}export default main;
 //# sourceMappingURL=terser-annotations.esm.js.map
 "
 `;
 
 exports[`fixtures build terser-annotations with microbundle 4`] = `
-"function shouldBePreserved(e,r){return e-r}module.exports=function(e,r){return{inlined:function(e,r){return e+r}(e,r),preserved:shouldBePreserved(e,r)}};
+"function shouldBePreserved(e,r){return e-r}module.exports=function(e,r){return{inlined:/*@__INLINE__*/function(e,r){return e+r}(e,r),preserved:/*@__NOINLINE__*/shouldBePreserved(e,r)}};
 //# sourceMappingURL=terser-annotations.js.map
 "
 `;
 
 exports[`fixtures build terser-annotations with microbundle 5`] = `
-"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e||self).terserAnnotations=n()}(this,function(){function shouldBePreserved(e,n){return e-n}return function(e,n){return{inlined:function(e,n){return e+n}(e,n),preserved:shouldBePreserved(e,n)}}});
+"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e||self).terserAnnotations=n()}(this,function(){function shouldBePreserved(e,n){return e-n}return function(e,n){return{inlined:/*@__INLINE__*/function(e,n){return e+n}(e,n),preserved:/*@__NOINLINE__*/shouldBePreserved(e,n)}}});
 //# sourceMappingURL=terser-annotations.umd.js.map
 "
 `;
@@ -2909,12 +2911,12 @@ ts-mixed-exports
 
 
 Build \\"tsMixedExports\\" to dist:
-112 B: ts-mixed-exports.js.gz
-89 B: ts-mixed-exports.js.br
-115 B: ts-mixed-exports.esm.js.gz
-100 B: ts-mixed-exports.esm.js.br
-212 B: ts-mixed-exports.umd.js.gz
-170 B: ts-mixed-exports.umd.js.br"
+130 B: ts-mixed-exports.js.gz
+104 B: ts-mixed-exports.js.br
+134 B: ts-mixed-exports.esm.js.gz
+118 B: ts-mixed-exports.esm.js.br
+228 B: ts-mixed-exports.umd.js.gz
+185 B: ts-mixed-exports.umd.js.br"
 `;
 
 exports[`fixtures build ts-mixed-exports with microbundle 2`] = `8`;
@@ -2938,19 +2940,19 @@ export default Ferrari;
 `;
 
 exports[`fixtures build ts-mixed-exports with microbundle 5`] = `
-"var t=function(){function t(){}return t.prototype.drive=function(t){return!0},t}(),n=new t;export default n;export{t as Car};
+"var t=/*#__PURE__*/function(){function t(){}return t.prototype.drive=function(t){return!0},t}(),n=new t;export default n;export{t as Car};
 //# sourceMappingURL=ts-mixed-exports.esm.js.map
 "
 `;
 
 exports[`fixtures build ts-mixed-exports with microbundle 6`] = `
-"var r=function(){function r(){}return r.prototype.drive=function(r){return!0},r}(),t=new r;exports.Car=r,exports.default=t;
+"var r=/*#__PURE__*/function(){function r(){}return r.prototype.drive=function(r){return!0},r}(),t=new r;exports.Car=r,exports.default=t;
 //# sourceMappingURL=ts-mixed-exports.js.map
 "
 `;
 
 exports[`fixtures build ts-mixed-exports with microbundle 7`] = `
-"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?n(exports):\\"function\\"==typeof define&&define.amd?define([\\"exports\\"],n):n((e||self).tsMixedExports={})}(this,function(e){var n=function(){function e(){}return e.prototype.drive=function(e){return!0},e}(),t=new n;e.Car=n,e.default=t});
+"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?n(exports):\\"function\\"==typeof define&&define.amd?define([\\"exports\\"],n):n((e||self).tsMixedExports={})}(this,function(e){var n=/*#__PURE__*/function(){function e(){}return e.prototype.drive=function(e){return!0},e}(),t=new n;e.Car=n,e.default=t});
 //# sourceMappingURL=ts-mixed-exports.umd.js.map
 "
 `;


### PR DESCRIPTION
Related to https://github.com/developit/microbundle/issues/871.

This PR fixes the regexp that preserves terser annotations in bundles.