### PR TITLE
Resolve using "node" export condition for --target node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -487,6 +487,7 @@ function createConfig(options, entry, format, writeMeta) {
 					nodeResolve({
 						mainFields: ['module', 'jsnext', 'main'],
 						browser: options.target !== 'node',
+						exportConditions: options.target === 'node' ? ['node'] : ['browser'],
 						// defaults + .jsx
 						extensions: ['.mjs', '.js', '.jsx', '.json', '.node'],
 						preferBuiltins: options.target === 'node',


### PR DESCRIPTION
When bundling for a Node.js target, Microbundle should follow the "node" conditional package export key to match Node's own resolution. Fixes #886.