### PR TITLE
fix: Corrects completion message to show the package's name, rather than the safe name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,8 +132,8 @@ export default async function microbundle(inputOptions) {
 	const targetDir = relative(cwd, dirname(options.output)) || '.';
 	const sourceExist = options.input.length > 0;
 	const banner = sourceExist
-		? blue(`Build "${options.name}" to ${targetDir}:`)
-		: red(`Error: No entry module found for "${options.name}"`);
+		? blue(`Build "${options.pkg.name}" to ${targetDir}:`)
+		: red(`Error: No entry module found for "${options.pkg.name}"`);
 	return {
 		output: `${banner}\n   ${out.join('\n   ')}`,
 	};

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -17,7 +17,7 @@ alias
     index.js
 
 
-Build \\"aliasMapping\\" to dist:
+Build \\"alias-mapping\\" to dist:
 62 B: alias-mapping.js.gz
 46 B: alias-mapping.js.br
 62 B: alias-mapping.esm.js.gz
@@ -62,7 +62,7 @@ alias-external
     index.js
 
 
-Build \\"aliasExternal\\" to dist:
+Build \\"alias-external\\" to dist:
 37 B: alias-external.js.gz
 21 B: alias-external.js.br
 37 B: alias-external.esm.js.gz
@@ -112,7 +112,7 @@ async-iife-ts
   tsconfig.json
 
 
-Build \\"asyncIifeTs\\" to dist:
+Build \\"async-iife-ts\\" to dist:
 70 B: async-iife-ts.js.gz
 55 B: async-iife-ts.js.br
 70 B: async-iife-ts.esm.js.gz
@@ -164,7 +164,7 @@ async-ts
   tsconfig.json
 
 
-Build \\"asyncTs\\" to dist:
+Build \\"async-ts\\" to dist:
 103 B: async-ts.js.gz
 72 B: async-ts.js.br
 112 B: async-ts.esm.js.gz
@@ -219,7 +219,7 @@ basic
     two.js
 
 
-Build \\"basicLib\\" to dist:
+Build \\"basic-lib\\" to dist:
 187 B: basic-lib.js.gz
 138 B: basic-lib.js.br
 188 B: basic-lib.esm.js.gz
@@ -266,7 +266,7 @@ basic-babelrc
     index.js
 
 
-Build \\"basicBabelrc\\" to dist:
+Build \\"basic-babelrc\\" to dist:
 122 B: basic-babelrc.js.gz
 91 B: basic-babelrc.js.br
 122 B: basic-babelrc.esm.js.gz
@@ -314,7 +314,7 @@ basic-compress-false
     two.js
 
 
-Build \\"basicCompressFalse\\" to dist:
+Build \\"basic-compress-false\\" to dist:
 260 B: basic-compress-false.js.gz
 206 B: basic-compress-false.js.br
 258 B: basic-compress-false.esm.js.gz
@@ -446,7 +446,7 @@ basic-css
     two.css
 
 
-Build \\"basicCss\\" to dist:
+Build \\"basic-css\\" to dist:
 107 B: basic-css.js.gz
 60 B: basic-css.js.br
 109 B: basic-css.esm.js.gz
@@ -499,7 +499,7 @@ basic-dashed-external
     two.js
 
 
-Build \\"basicDashedExternal\\" to dist:
+Build \\"basic-dashed-external\\" to dist:
 259 B: basic-dashed-external.js.gz
 196 B: basic-dashed-external.js.br
 214 B: basic-dashed-external.esm.js.gz
@@ -547,7 +547,7 @@ basic-flow
     index.js
 
 
-Build \\"basicLibFlow\\" to dist:
+Build \\"basic-lib-flow\\" to dist:
 57 B: basic-lib-flow.js.gz
 43 B: basic-lib-flow.js.br
 56 B: basic-lib-flow.esm.js.gz
@@ -595,7 +595,7 @@ basic-json
     two.json
 
 
-Build \\"basicJson\\" to dist:
+Build \\"basic-json\\" to dist:
 93 B: basic-json.js.gz
 65 B: basic-json.js.br
 92 B: basic-json.esm.js.gz
@@ -648,7 +648,7 @@ basic-multi-source
   package.json
 
 
-Build \\"basicMultiSource\\" to dist:
+Build \\"basic-multi-source\\" to dist:
 43 B: a.js.gz
 27 B: a.js.br
 43 B: a.esm.js.gz
@@ -720,7 +720,7 @@ basic-no-compress
     two.js
 
 
-Build \\"basicNoCompress\\" to dist:
+Build \\"basic-no-compress\\" to dist:
 260 B: basic-no-compress.js.gz
 206 B: basic-no-compress.js.br
 258 B: basic-no-compress.esm.js.gz
@@ -846,7 +846,7 @@ basic-no-pkg-main
     two.js
 
 
-Build \\"basicNoPkgMain\\" to dist:
+Build \\"basic-no-pkg-main\\" to dist:
 187 B: basic-no-pkg-main.js.gz
 138 B: basic-no-pkg-main.js.br
 188 B: basic-no-pkg-main.js.gz
@@ -877,7 +877,7 @@ basic-node-internals
     index.js
 
 
-Build \\"basicNodeInternals\\" to dist:
+Build \\"basic-node-internals\\" to dist:
 191 B: basic-node-internals.js.gz
 149 B: basic-node-internals.js.br"
 `;
@@ -927,7 +927,7 @@ basic-ts
   tsconfig.json
 
 
-Build \\"basicLibTs\\" to dist:
+Build \\"basic-lib-ts\\" to dist:
 104 B: basic-lib-ts.js.gz
 76 B: basic-lib-ts.js.br
 104 B: basic-lib-ts.esm.js.gz
@@ -994,7 +994,7 @@ basic-tsx
   tsconfig.json
 
 
-Build \\"basicLibTsx\\" to dist:
+Build \\"basic-lib-tsx\\" to dist:
 199 B: basic-lib-tsx.js.gz
 153 B: basic-lib-tsx.js.br
 200 B: basic-lib-tsx.esm.js.gz
@@ -1099,7 +1099,7 @@ class-decorators-ts
   tsconfig.json
 
 
-Build \\"classDecoratorsTs\\" to dist:
+Build \\"class-decorators-ts\\" to dist:
 333 B: class-decorators-ts.js.gz
 276 B: class-decorators-ts.js.br
 333 B: class-decorators-ts.esm.js.gz
@@ -1157,7 +1157,7 @@ class-properties
     index.js
 
 
-Build \\"classProperties\\" to dist:
+Build \\"class-properties\\" to dist:
 93 B: class-properties.js.gz
 79 B: class-properties.js.br
 96 B: class-properties.esm.js.gz
@@ -1204,7 +1204,7 @@ css-modules--false
     not_scoped.module.css
 
 
-Build \\"cssModulesFalse\\" to dist:
+Build \\"css-modules--false\\" to dist:
 49 B: css-modules--false.js.gz
 23 B: css-modules--false.js.br
 52 B: css-modules--false.esm.js.gz
@@ -1250,7 +1250,7 @@ css-modules--null
     scoped.module.css
 
 
-Build \\"cssModulesNull\\" to dist:
+Build \\"css-modules--null\\" to dist:
 110 B: css-modules--null.js.gz
 72 B: css-modules--null.js.br
 112 B: css-modules--null.esm.js.gz
@@ -1296,7 +1296,7 @@ css-modules--string
     scoped.module.css
 
 
-Build \\"cssModulesString\\" to dist:
+Build \\"css-modules--string\\" to dist:
 166 B: css-modules--string.js.gz
 118 B: css-modules--string.js.br
 168 B: css-modules--string.esm.js.gz
@@ -1342,7 +1342,7 @@ css-modules--true
     scoped.module.css
 
 
-Build \\"cssModulesTrue\\" to dist:
+Build \\"css-modules--true\\" to dist:
 139 B: css-modules--true.js.gz
 94 B: css-modules--true.js.br
 141 B: css-modules--true.esm.js.gz
@@ -1388,7 +1388,7 @@ custom-babelrc
     index.js
 
 
-Build \\"customBabelrc\\" to dist:
+Build \\"custom-babelrc\\" to dist:
 218 B: custom-babelrc.js.gz
 193 B: custom-babelrc.js.br
 222 B: custom-babelrc.esm.js.gz
@@ -1436,7 +1436,7 @@ custom-source
     two.js
 
 
-Build \\"customSource\\" to dist:
+Build \\"custom-source\\" to dist:
 187 B: custom-source.js.gz
 138 B: custom-source.js.br
 188 B: custom-source.esm.js.gz
@@ -1484,7 +1484,7 @@ custom-source
     two.js
 
 
-Build \\"customSrc\\" to dist:
+Build \\"custom-src\\" to dist:
 187 B: custom-src.js.gz
 138 B: custom-src.js.br
 188 B: custom-src.esm.js.gz
@@ -1531,7 +1531,7 @@ default-named
     index.js
 
 
-Build \\"defaultNamed\\" to dist:
+Build \\"default-named\\" to dist:
 60 B: default-named.js.gz
 46 B: default-named.js.br
 74 B: default-named.esm.js.gz
@@ -1612,7 +1612,7 @@ define-expression
   package.json
 
 
-Build \\"defineExpression\\" to dist:
+Build \\"define-expression\\" to dist:
 56 B: define-expression.esm.js.gz
 40 B: define-expression.esm.js.br"
 `;
@@ -1645,7 +1645,7 @@ esnext-ts
   tsconfig.json
 
 
-Build \\"esnextTs\\" to dist:
+Build \\"esnext-ts\\" to dist:
 989 B: esnext-ts.js.gz
 883 B: esnext-ts.js.br
 990 B: esnext-ts.esm.js.gz
@@ -1695,7 +1695,7 @@ inline-source-map
     two.js
 
 
-Build \\"inlineSourceMap\\" to dist:
+Build \\"inline-source-map\\" to dist:
 187 B: inline-source-map.js.gz
 138 B: inline-source-map.js.br
 188 B: inline-source-map.esm.js.gz
@@ -1789,7 +1789,7 @@ macro
     macro.js
 
 
-Build \\"macroLib\\" to dist:
+Build \\"macro-lib\\" to dist:
 49 B: macro-lib.js.gz
 33 B: macro-lib.js.br
 48 B: macro-lib.esm.js.gz
@@ -1838,7 +1838,7 @@ mangle-json-file
     two.js
 
 
-Build \\"mangleJsonFile\\" to dist:
+Build \\"mangle-json-file\\" to dist:
 103 B: mangle-json-file.js.gz
 89 B: mangle-json-file.js.br
 105 B: mangle-json-file.esm.js.gz
@@ -1886,7 +1886,7 @@ minify-config
     two.js
 
 
-Build \\"minifyConfig\\" to dist:
+Build \\"minify-config\\" to dist:
 99 B: minify-config.js.gz
 85 B: minify-config.js.br
 101 B: minify-config.esm.js.gz
@@ -1934,7 +1934,7 @@ minify-config-boolean
     two.js
 
 
-Build \\"minifyConfigBoolean\\" to dist:
+Build \\"minify-config-boolean\\" to dist:
 107 B: minify-config-boolean.js.gz
 84 B: minify-config-boolean.js.br
 114 B: minify-config-boolean.esm.js.gz
@@ -1983,7 +1983,7 @@ minify-path-config
     two.js
 
 
-Build \\"minifyPathConfig\\" to dist:
+Build \\"minify-path-config\\" to dist:
 103 B: minify-path-config.js.gz
 89 B: minify-path-config.js.br
 105 B: minify-path-config.esm.js.gz
@@ -2030,7 +2030,7 @@ minify-path-parent-dir
   two.js
 
 
-Build \\"minifyPathParentDir\\" to dist:
+Build \\"minify-path-parent-dir\\" to dist:
 103 B: minify-path-parent-dir.js.gz
 89 B: minify-path-parent-dir.js.br
 105 B: minify-path-parent-dir.esm.js.gz
@@ -2074,7 +2074,7 @@ modern
     two.js
 
 
-Build \\"modernLib\\" to dist:
+Build \\"modern-lib\\" to dist:
 113 B: modern-lib.modern.js.gz
 92 B: modern-lib.modern.js.br"
 `;
@@ -2108,7 +2108,7 @@ modern-generators
     two.js
 
 
-Build \\"modernGenerators\\" to dist:
+Build \\"modern-generators\\" to dist:
 234 B: modern-generators.js.gz
 207 B: modern-generators.js.br
 118 B: modern-generators.modern.js.gz
@@ -2164,7 +2164,7 @@ name-custom-amd
     two.js
 
 
-Build \\"customNameAmd\\" to dist:
+Build \\"name-custom-amd\\" to dist:
 187 B: name-custom-amd.js.gz
 138 B: name-custom-amd.js.br
 188 B: name-custom-amd.esm.js.gz
@@ -2212,7 +2212,7 @@ name-custom-cli
     two.js
 
 
-Build \\"nameCustomCli\\" to dist:
+Build \\"name-custom\\" to dist:
 187 B: name-custom.js.gz
 138 B: name-custom.js.br
 188 B: name-custom.esm.js.gz
@@ -2259,7 +2259,7 @@ no-pkg
     two.js
 
 
-Build \\"noPkg\\" to dist:
+Build \\"no-pkg\\" to dist:
 187 B: no-pkg.js.gz
 138 B: no-pkg.js.br
 188 B: no-pkg.esm.js.gz
@@ -2307,7 +2307,7 @@ no-pkg-name
     two.js
 
 
-Build \\"noPkgName\\" to dist:
+Build \\"no-pkg-name\\" to dist:
 187 B: no-pkg-name.js.gz
 138 B: no-pkg-name.js.br
 188 B: no-pkg-name.esm.js.gz
@@ -2357,7 +2357,7 @@ optional-chaining-ts
   tsconfig.json
 
 
-Build \\"optionalChainingTs\\" to dist:
+Build \\"optional-chaining-ts\\" to dist:
 109 B: optional-chaining-ts.js.gz
 88 B: optional-chaining-ts.js.br
 111 B: optional-chaining-ts.esm.js.gz
@@ -2413,7 +2413,7 @@ parameters-rest-closure
     index.js
 
 
-Build \\"parametersRestClosure\\" to dist:
+Build \\"parameters-rest-closure\\" to dist:
 157 B: parameters-rest-closure.js.gz
 115 B: parameters-rest-closure.js.br
 165 B: parameters-rest-closure.esm.js.gz
@@ -2505,7 +2505,7 @@ publish-config
     foo.ts
 
 
-Build \\"publishConfig\\" to dist:
+Build \\"publish-config\\" to dist:
 55 B: bar.js.gz
 33 B: bar.js.br"
 `;
@@ -2686,7 +2686,7 @@ terser-annotations
     index.js
 
 
-Build \\"terserAnnotations\\" to dist:
+Build \\"terser-annotations\\" to dist:
 112 B: terser-annotations.js.gz
 86 B: terser-annotations.js.br
 117 B: terser-annotations.esm.js.gz
@@ -2736,7 +2736,7 @@ ts-custom-declaration
     index.d.ts
 
 
-Build \\"tsCustomDeclarations\\" to dist:
+Build \\"ts-custom-declarations\\" to dist:
 55 B: index.js.gz
 33 B: index.js.br
 61 B: index.esm.js.gz
@@ -2794,7 +2794,7 @@ ts-declaration
     index.d.ts
 
 
-Build \\"tsDeclarations\\" to dist:
+Build \\"ts-declarations\\" to dist:
 55 B: index.js.gz
 33 B: index.js.br
 61 B: index.esm.js.gz
@@ -2851,7 +2851,7 @@ ts-jsx
   tsconfig.json
 
 
-Build \\"tsJsx\\" to dist:
+Build \\"ts-jsx\\" to dist:
 130 B: ts-jsx.js.gz
 94 B: ts-jsx.js.br
 131 B: ts-jsx.esm.js.gz
@@ -2908,7 +2908,7 @@ ts-mixed-exports
   tsconfig.json
 
 
-Build \\"tsMixedExports\\" to dist:
+Build \\"ts-mixed-exports\\" to dist:
 112 B: ts-mixed-exports.js.gz
 89 B: ts-mixed-exports.js.br
 115 B: ts-mixed-exports.esm.js.gz
@@ -2978,7 +2978,7 @@ ts-module
   tsconfig.json
 
 
-Build \\"tsModule\\" to dist:
+Build \\"ts-module\\" to dist:
 59 B: ts-module.js.gz
 42 B: ts-module.js.br
 65 B: ts-module.esm.js.gz


### PR DESCRIPTION
Corrects a minor annoyance

As far as I know there's no reason we need to display the safe name here, and (IMO) it's better if the displayed name actually matches the package name.