### PR TITLE
docs: Update obsolete `default` exports in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The filenames and paths for generated bundles in each format are defined by the 
   "module": "dist/foo.m.js",           // ES Modules output bundle 
   "exports": {
     "require": "./dist/foo.js",        // CommonJS output bundle
-    "default": "./dist/foo.modern.js", // Modern ES Modules output bundle
+    "import": "./dist/foo.modern.js", // Modern ES Modules output bundle
   },
   "types": "dist/foo.d.ts"             // TypeScript typings directory
 }


### PR DESCRIPTION
Current example uses `default`, which is no longer valid based the following code 

https://github.com/developit/microbundle/blob/b1a637486234a2ae784ccf0c512321e2d3efef7c/src/index.js#L262-L265