### PR TITLE
Remove declaration dir warning when declarations are disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -227,6 +227,14 @@ async function getOutput({ cwd, output, pkgMain, pkgName }) {
 }
 
 function getDeclarationDir({ options, pkg }) {
+	try {
+		const tsconfig = JSON.parse(fs.readFileSync(options.tsconfig || "tsconfig.json", 'utf-8'))
+
+		if (tsconfig && tsconfig.compilerOptions && tsconfig.compilerOptions.declaration === false) {
+			return undefined;
+		}
+	} catch(err) {}
+
 	const { cwd, output } = options;
 
 	let result = output;


### PR DESCRIPTION
# About

Given the following tsconfig

```json
{
  "compilerOptions": {
    "declaration": false
  }
}
```

The user will see this message whenever building

> rpt2: options error TS5069: Option 'declarationDir' cannot be specified without specifying option 'declaration' or option 'composite'.

This PR introduces a check to only provide a `declarationDir` option to rollup if declarations aren't omitted.

# Other stuff

This is just a proposal - the `tsconfig.json` would need to be properly interpreted in order to get the `declaration` value (e.g. to cover `extends`).