### PR TITLE
Rollup tweaks for output size/perf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -680,6 +680,8 @@ function createConfig(options, entry, format, writeMeta) {
 			strict: options.strict === true,
 			freeze: false,
 			esModule: false,
+			generatedCode: modern ? 'es2015' : 'es5',
+			externalLiveBindings: false,
 			sourcemap: options.sourcemap,
 			get banner() {
 				return shebang[options.name];


### PR DESCRIPTION
This turns off `externalLiveBindings`, which generates getters for re-exported bindings.
It also enables modern code generation for the modern bundles (arrow functions, object shorthand, etc).