### PR TITLE
chore: Adding flag & docs for jsxFragment

### DIFF
--- a/.changeset/odd-mayflies-clap.md
+++ b/.changeset/odd-mayflies-clap.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Documenting --jsxFragment flag

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Options
 	--sourcemap        Generate source map  (default true)
 	--raw              Show raw byte size  (default false)
 	--jsx              A custom JSX pragma like React.createElement (default: h)
+	--jsxFragment      A custom JSX fragment pragma like React.Fragment (default: Fragment)
 	--jsxImportSource  Declares the module specifier to be used for importing jsx factory functions
 	--tsconfig         Specify the path to a custom tsconfig.json
 	--generateTypes    Whether or not to generate types, if `types` or `typings` is set in `package.json` then it will default to be `true`

--- a/src/index.js
+++ b/src/index.js
@@ -537,12 +537,8 @@ function createConfig(options, entry, format, writeMeta) {
 										declarationDir: getDeclarationDir({ options, pkg }),
 									}),
 									jsx: 'preserve',
-									jsxFactory:
-										// TypeScript fails to resolve Fragments when jsxFactory
-										// is set, even when it's the same as the default value.
-										options.jsx === 'React.createElement'
-											? undefined
-											: options.jsx || 'h',
+									jsxFactory: options.jsx,
+									jsxFragmentFactory: options.jsxFragment,
 								},
 								files: options.entries,
 							},
@@ -579,8 +575,8 @@ function createConfig(options, entry, format, writeMeta) {
 							modern,
 							compress: options.compress !== false,
 							targets: options.target === 'node' ? { node: '8' } : undefined,
-							pragma: options.jsx || 'h',
-							pragmaFrag: options.jsxFragment || 'Fragment',
+							pragma: options.jsx,
+							pragmaFrag: options.jsxFragment,
 							typescript: !!useTypescript,
 							jsxImportSource: options.jsxImportSource || false,
 						},

--- a/src/prog.js
+++ b/src/prog.js
@@ -60,6 +60,11 @@ export default handler => {
 		.option('--raw', 'Show raw byte size', false)
 		.option('--jsx', 'A custom JSX pragma like React.createElement', 'h')
 		.option(
+			'--jsxFragment',
+			'A custom JSX fragment pragma like React.Fragment',
+			'Fragment',
+		)
+		.option(
 			'--jsxImportSource',
 			'Declares the module specifier to be used for importing jsx factory functions',
 		)


### PR DESCRIPTION
https://github.com/developit/microbundle/issues/809#issuecomment-1025937798

I removed the `options.jsx === 'React.createElement'` thing as it's no longer relevant with `jsxFragmentFactory` (see https://github.com/developit/microbundle/pull/623#issuecomment-632442811) and we set default values in the CLI for both `jsx` and `jsxFragment`, so we don't really need extra fallback values.