### PR TITLE
docs: compress flag

### DIFF
--- a/.changeset/big-cameras-attend.md
+++ b/.changeset/big-cameras-attend.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Adds information about `--compress` flag's default value w/ different targets

--- a/README.md
+++ b/README.md
@@ -328,19 +328,19 @@ Options
 	--globals          Specify globals dependencies, or 'none'
 	--define           Replace constants with hard-coded values (use @key=exp to replace an expression)
 	--alias            Map imports to different modules
-	--compress         Compress output using Terser
+	--compress         Compress output using Terser (default true when --target is web, false when --target is node)
 	--strict           Enforce undefined global context and add "use strict"
 	--name             Specify name exposed in UMD and IIFE builds
 	--cwd              Use an alternative working directory  (default .)
 	--sourcemap        Generate source map  (default true)
 	--raw              Show raw byte size  (default false)
-	--jsx              A custom JSX pragma like React.createElement (default: h)
-	--jsxFragment      A custom JSX fragment pragma like React.Fragment (default: Fragment)
+	--jsx              A custom JSX pragma like React.createElement (default h)
+	--jsxFragment      A custom JSX fragment pragma like React.Fragment (default Fragment)
 	--jsxImportSource  Declares the module specifier to be used for importing jsx factory functions
 	--tsconfig         Specify the path to a custom tsconfig.json
 	--generateTypes    Whether or not to generate types, if `types` or `typings` is set in `package.json` then it will default to be `true`
-	--css              Where to output CSS: "inline" or "external" (default: "external")
-	--css-modules      Configures .css to be treated as modules (default: null)
+	--css              Where to output CSS: "inline" or "external" (default "external")
+	--css-modules      Configures .css to be treated as modules (default null)
 	--workers          Bundle module workers - see https://git.io/J3oSF  (default false)
 	-h, --help         Displays this message
 

--- a/src/prog.js
+++ b/src/prog.js
@@ -13,7 +13,7 @@ export default handler => {
 
 		opts.entries = toArray(str || opts.entry).concat(opts._);
 
-		if (opts.compress != null) {
+		if (typeof opts.compress !== 'undefined') {
 			// Convert `--compress true/false/1/0` to booleans:
 			if (typeof opts.compress !== 'boolean') {
 				opts.compress = opts.compress !== 'false' && opts.compress !== '0';
@@ -51,7 +51,11 @@ export default handler => {
 		.example('--define API_KEY=1234')
 		.option('--alias', `Map imports to different modules`)
 		.example('--alias react=preact')
-		.option('--compress', 'Compress output using Terser', null)
+		.option(
+			'--compress',
+			'Compress output using Terser (default true when --target is web, false when --target is node)',
+		)
+		.example('build --target web --no-compress')
 		.option('--strict', 'Enforce undefined global context and add "use strict"')
 		.option('--name', 'Specify name exposed in UMD builds')
 		.option('--cwd', 'Use an alternative working directory', '.')


### PR DESCRIPTION
Adds information on default value of `--compress` flag, as that seems to be a popular complaint at the moment.

CLI needed to switch to having an undefined value to ensure Sade didn't document the default value in addition to the default value we write in the description of the flag. Just means we have to switch the `null` check to `undefined`.

Also fixes some formatting inconsistencies for other default values.