### PR TITLE
fix: tsconfig cwd differing from microbundle's cwd

### DIFF
--- a/.changeset/clever-chicken-end.md
+++ b/.changeset/clever-chicken-end.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Ensures TS plugin will begin its search for a 'tsconfig.json' in the set cwd

--- a/src/index.js
+++ b/src/index.js
@@ -520,6 +520,7 @@ function createConfig(options, entry, format, writeMeta) {
 					},
 					(useTypescript || emitDeclaration) &&
 						typescript({
+							cwd: options.cwd,
 							typescript: require(resolveFrom.silent(
 								options.cwd,
 								'typescript',


### PR DESCRIPTION
Closes #939

Simply ensures the TS plugin will begin its search for a `tsconfig.json` in the specified `--cwd`.

This is not a breaking change; in the case of a `tsconfig.json` only existing higher in a project structure, and not in the passed `--cwd`, rpt2 (which makes use of `typescript` itself, actually) will ascend the file tree attempting to discover a config file.