### PR TITLE
fix: babel exclude for hoisted modules

### DIFF
--- a/.changeset/hip-olives-allow.md
+++ b/.changeset/hip-olives-allow.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Ensures hoisted node_modules are excluded from babel

--- a/src/index.js
+++ b/src/index.js
@@ -569,7 +569,8 @@ function createConfig(options, entry, format, writeMeta) {
 					customBabel()({
 						babelHelpers: 'bundled',
 						extensions: EXTENSIONS,
-						exclude: 'node_modules/**',
+						// use a regex to make sure to exclude eventual hoisted packages
+						exclude: /\/node_modules\//,
 						passPerPreset: true, // @see https://babeljs.io/docs/en/options#passperpreset
 						custom: {
 							defines,


### PR DESCRIPTION
Closes #946