### PR TITLE
fix: build message formatting

### DIFF
--- a/.changeset/smart-plants-appear.md
+++ b/.changeset/smart-plants-appear.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Corrects formatting in build completion message w/ dynamic import is used

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ export default async function microbundle(inputOptions) {
 		? blue(`Build "${options.pkg.name}" to ${targetDir}:`)
 		: red(`Error: No entry module found for "${options.pkg.name}"`);
 	return {
-		output: `${banner}\n   ${out.join('\n   ')}`,
+		output: `${banner}\n${out.join('\n')}`,
 	};
 }
 

--- a/src/lib/compressed-size.js
+++ b/src/lib/compressed-size.js
@@ -11,7 +11,7 @@ function getPadLeft(str, width, char = ' ') {
 function formatSize(size, filename, type, raw) {
 	const pretty = raw ? `${size} B` : prettyBytes(size);
 	const color = size < 5000 ? green : size > 40000 ? red : yellow;
-	const indent = getPadLeft(pretty, type === 'br' ? 13 : 10);
+	const indent = getPadLeft(pretty, 13);
 	return `${indent}${color(pretty)}: ${white(basename(filename))}.${type}`;
 }
 


### PR DESCRIPTION
Super minor, but when building a source file that contained a dynamic import for another module, this would be the result in the user's terminal:

![Image of build output message](https://user-images.githubusercontent.com/33403762/164372330-4d2ee489-3cad-4b75-aa7b-06d03ea7211e.png)

Simple solution was to remove the extra spaces from the template string & make the left padding consistent across formats.