### PR TITLE
Remove git.io usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Options
 	--generateTypes    Whether or not to generate types, if `types` or `typings` is set in `package.json` then it will default to be `true`
 	--css              Where to output CSS: "inline" or "external" (default "external")
 	--css-modules      Configures .css to be treated as modules (default null)
-	--workers          Bundle module workers - see https://git.io/J3oSF  (default false)
+	--workers          Bundle module workers - see https://github.com/surma/rollup-plugin-off-main-thread#auto-bundling  (default false)
 	--visualize        Generate bundle makeup visualization (stats.html)
 	-h, --help         Displays this message
 

--- a/src/prog.js
+++ b/src/prog.js
@@ -86,7 +86,7 @@ export default handler => {
 		)
 		.option(
 			'--workers',
-			'Bundle module workers - see https://git.io/J3oSF',
+			'Bundle module workers - see https://github.com/surma/rollup-plugin-off-main-thread#auto-bundling',
 			false,
 		)
 		.option(


### PR DESCRIPTION
See https://github.blog/changelog/2022-04-25-git-io-deprecation/.

Apologies in advance for the incoming barrage of PRs doing the exact same thing, hope you don't mind.
