### PR TITLE
chore: Bump Node target version to v12

### DIFF
--- a/.changeset/breezy-cheetahs-kick.md
+++ b/.changeset/breezy-cheetahs-kick.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Bumps Node target to v12

--- a/src/index.js
+++ b/src/index.js
@@ -593,7 +593,7 @@ function createConfig(options, entry, format, writeMeta) {
 							defines,
 							modern,
 							compress: options.compress !== false,
-							targets: options.target === 'node' ? { node: '8' } : undefined,
+							targets: options.target === 'node' ? { node: '12' } : undefined,
 							pragma: options.jsx,
 							pragmaFrag: options.jsxFragment,
 							typescript: !!useTypescript,


### PR DESCRIPTION
I don't think there's many, if any, situations in which this would be a problem per se, but v8 is a bit old now. Just happened to noticed unused `catch` bindings being created, rather than allowing them to be omitted in Microbundle's output ([supported since Node v10](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#browser_compatibility)). 

As v12 has only been EOL for 3 days now, I figure it might be a bit early to bump this to v14.