### PR TITLE
chore: Silence warnings when using 'node:' protocol

### DIFF
--- a/.changeset/hot-dryers-train.md
+++ b/.changeset/hot-dryers-train.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Silences warnings when using Node builtins with the 'node:...' protocol on imports. Warnings related to bare usage of these builtins were already silenced.

--- a/src/index.js
+++ b/src/index.js
@@ -347,7 +347,7 @@ function createConfig(options, entry, format, writeMeta) {
 	// We want to silence rollup warnings for node builtins as we rollup-node-resolve threats them as externals anyway
 	// @see https://github.com/rollup/plugins/tree/master/packages/node-resolve/#resolving-built-ins-like-fs
 	if (options.target === 'node') {
-		external = external.concat(builtinModules);
+		external = [/node:.*/].concat(builtinModules);
 	}
 
 	const peerDeps = Object.keys(pkg.peerDependencies || {});


### PR DESCRIPTION
The current solution for matching builtins doesn't catch imports using the new-ish `node:` protocol:

```
Failed to resolve the module node:http imported by src/index.js
Is the module installed? Note:
 ↳ to inline a module into your bundle, install it to "devDependencies".
 ↳ to depend on a module via import/require, install it to "dependencies".
```

This just adds it to the patterns to match against when the target for Microbundle is Node.