### PR TITLE
Remove mention of UMD support for web workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ This can be customized by passing the command line argument `--css-modules "[nam
 ### Building Module Workers
 
 Microbundle is able to detect and bundle Module Workers when generating bundles in the
-`es`, `umd` and `modern` formats. To use this feature, instantiate your Web Worker as follows:
+`es` and `modern` formats. To use this feature, instantiate your Web Worker as follows:
 
 ```js
 worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ This can be customized by passing the command line argument `--css-modules "[nam
 ### Building Module Workers
 
 Microbundle is able to detect and bundle Module Workers when generating bundles in the
-`es` and `modern` formats. To use this feature, instantiate your Web Worker as follows:
+`esm` and `modern` formats. To use this feature, instantiate your Web Worker as follows:
 
 ```js
 worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });


### PR DESCRIPTION
OMT only supports amd or esm as output, so the readme should not
mention umd as supported.

When executing microbundle with umd format and `--workers`, the web
worker will fail to be detected or bundled.