### PR TITLE
fix: mains by format fallbacks

### DIFF
--- a/.changeset/old-dodos-laugh.md
+++ b/.changeset/old-dodos-laugh.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Fixes filename generation for es & modern outputs. Both 'jsnext:main' and 'esmodule' were incorrectly ignored.

--- a/src/index.js
+++ b/src/index.js
@@ -302,9 +302,7 @@ function getMain({ options, entry, format }) {
 	mainsByFormat.es = replaceName(
 		pkg.module && !pkg.module.match(/src\//)
 			? pkg.module
-			: pkg['jsnext:main'] || pkgTypeModule
-			? 'x.esm.js'
-			: 'x.esm.mjs',
+			: pkg['jsnext:main'] || (pkgTypeModule ? 'x.esm.js' : 'x.esm.mjs'),
 		mainNoExtension,
 	);
 
@@ -312,9 +310,7 @@ function getMain({ options, entry, format }) {
 		(pkg.exports && walk(pkg.exports, pkgTypeModule)) ||
 			(pkg.syntax && pkg.syntax.esmodules) ||
 			pkg.esmodule ||
-			pkgTypeModule
-			? 'x.modern.js'
-			: 'x.modern.mjs',
+			(pkgTypeModule ? 'x.modern.js' : 'x.modern.mjs'),
 		mainNoExtension,
 	);
 	mainsByFormat.cjs = replaceName(

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1418,6 +1418,122 @@ exports[`fixtures build custom-babelrc with microbundle 5`] = `
 "
 `;
 
+exports[`fixtures build custom-outputs with microbundle 1`] = `
+"Used script: microbundle -f modern,es,umd,cjs
+
+Directory tree:
+
+custom-outputs
+  dist
+    custom-outputs.exportsx.mjs
+    custom-outputs.exportsx.mjs.map
+    custom-outputs.js
+    custom-outputs.js.map
+    custom-outputs.modulex.mjs
+    custom-outputs.modulex.mjs.map
+    custom-outputs.umdx.js
+    custom-outputs.umdx.js.map
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"custom-outputs\\" to dist:
+187 B: custom-outputs.js.gz
+138 B: custom-outputs.js.br
+113 B: custom-outputs.exportsx.mjs.gz
+92 B: custom-outputs.exportsx.mjs.br
+188 B: custom-outputs.modulex.mjs.gz
+139 B: custom-outputs.modulex.mjs.br
+273 B: custom-outputs.umdx.js.gz
+203 B: custom-outputs.umdx.js.br"
+`;
+
+exports[`fixtures build custom-outputs with microbundle 2`] = `8`;
+
+exports[`fixtures build custom-outputs with microbundle 3`] = `
+"async function n(...n){return n.reduce((n,t)=>n+t,0)}async function t(...t){return[await n(...t),await n(...t)]}export default t;
+//# sourceMappingURL=custom-outputs.exportsx.mjs.map
+"
+`;
+
+exports[`fixtures build custom-outputs with microbundle 4`] = `
+"var r=function(){try{var r=arguments;return Promise.resolve([].slice.call(r).reduce(function(r,e){return r+e},0))}catch(r){return Promise.reject(r)}};module.exports=function(){try{var e=arguments,t=[].slice.call(e);return Promise.resolve(r.apply(void 0,t)).then(function(e){return Promise.resolve(r.apply(void 0,t)).then(function(r){return[e,r]})})}catch(r){return Promise.reject(r)}};
+//# sourceMappingURL=custom-outputs.js.map
+"
+`;
+
+exports[`fixtures build custom-outputs with microbundle 5`] = `
+"var r=function(){try{var r=arguments;return Promise.resolve([].slice.call(r).reduce(function(r,e){return r+e},0))}catch(r){return Promise.reject(r)}};export default function(){try{var e=arguments,t=[].slice.call(e);return Promise.resolve(r.apply(void 0,t)).then(function(e){return Promise.resolve(r.apply(void 0,t)).then(function(r){return[e,r]})})}catch(r){return Promise.reject(r)}}
+//# sourceMappingURL=custom-outputs.modulex.mjs.map
+"
+`;
+
+exports[`fixtures build custom-outputs with microbundle 6`] = `
+"!function(e,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define(t):(e||self).customOutputs=t()}(this,function(){var e=function(){try{var e=arguments;return Promise.resolve([].slice.call(e).reduce(function(e,t){return e+t},0))}catch(e){return Promise.reject(e)}};return function(){try{var t=arguments,r=[].slice.call(t);return Promise.resolve(e.apply(void 0,r)).then(function(t){return Promise.resolve(e.apply(void 0,r)).then(function(e){return[t,e]})})}catch(e){return Promise.reject(e)}}});
+//# sourceMappingURL=custom-outputs.umdx.js.map
+"
+`;
+
+exports[`fixtures build custom-outputs-alt with microbundle 1`] = `
+"Used script: microbundle -f modern,es,umd,cjs
+
+Directory tree:
+
+custom-outputs-alt
+  dist
+    custom-outputs-alt.cjsmain.js
+    custom-outputs-alt.cjsmain.js.map
+    custom-outputs-alt.esmodule.mjs
+    custom-outputs-alt.esmodule.mjs.map
+    custom-outputs-alt.jsnextmain.mjs
+    custom-outputs-alt.jsnextmain.mjs.map
+    custom-outputs-alt.unpkg.js
+    custom-outputs-alt.unpkg.js.map
+  package.json
+  src
+    index.js
+    two.js
+
+
+Build \\"custom-outputs-alt\\" to dist:
+187 B: custom-outputs-alt.cjsmain.js.gz
+138 B: custom-outputs-alt.cjsmain.js.br
+113 B: custom-outputs-alt.esmodule.mjs.gz
+92 B: custom-outputs-alt.esmodule.mjs.br
+188 B: custom-outputs-alt.jsnextmain.mjs.gz
+139 B: custom-outputs-alt.jsnextmain.mjs.br
+277 B: custom-outputs-alt.unpkg.js.gz
+226 B: custom-outputs-alt.unpkg.js.br"
+`;
+
+exports[`fixtures build custom-outputs-alt with microbundle 2`] = `8`;
+
+exports[`fixtures build custom-outputs-alt with microbundle 3`] = `
+"var r=function(){try{var r=arguments;return Promise.resolve([].slice.call(r).reduce(function(r,e){return r+e},0))}catch(r){return Promise.reject(r)}};module.exports=function(){try{var e=arguments,t=[].slice.call(e);return Promise.resolve(r.apply(void 0,t)).then(function(e){return Promise.resolve(r.apply(void 0,t)).then(function(r){return[e,r]})})}catch(r){return Promise.reject(r)}};
+//# sourceMappingURL=custom-outputs-alt.cjsmain.js.map
+"
+`;
+
+exports[`fixtures build custom-outputs-alt with microbundle 4`] = `
+"async function n(...n){return n.reduce((n,t)=>n+t,0)}async function t(...t){return[await n(...t),await n(...t)]}export default t;
+//# sourceMappingURL=custom-outputs-alt.esmodule.mjs.map
+"
+`;
+
+exports[`fixtures build custom-outputs-alt with microbundle 5`] = `
+"var r=function(){try{var r=arguments;return Promise.resolve([].slice.call(r).reduce(function(r,e){return r+e},0))}catch(r){return Promise.reject(r)}};export default function(){try{var e=arguments,t=[].slice.call(e);return Promise.resolve(r.apply(void 0,t)).then(function(e){return Promise.resolve(r.apply(void 0,t)).then(function(r){return[e,r]})})}catch(r){return Promise.reject(r)}}
+//# sourceMappingURL=custom-outputs-alt.jsnextmain.mjs.map
+"
+`;
+
+exports[`fixtures build custom-outputs-alt with microbundle 6`] = `
+"!function(e,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=t():\\"function\\"==typeof define&&define.amd?define(t):(e||self).customOutputsAlt=t()}(this,function(){var e=function(){try{var e=arguments;return Promise.resolve([].slice.call(e).reduce(function(e,t){return e+t},0))}catch(e){return Promise.reject(e)}};return function(){try{var t=arguments,r=[].slice.call(t);return Promise.resolve(e.apply(void 0,r)).then(function(t){return Promise.resolve(e.apply(void 0,r)).then(function(e){return[t,e]})})}catch(e){return Promise.reject(e)}}});
+//# sourceMappingURL=custom-outputs-alt.unpkg.js.map
+"
+`;
+
 exports[`fixtures build custom-source with microbundle 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/custom-outputs-alt/package.json
+++ b/test/fixtures/custom-outputs-alt/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "custom-outputs-alt",
+  "cjs:main": "dist/custom-outputs-alt.cjsmain.js",
+  "unpkg": "dist/custom-outputs-alt.unpkg.js",
+  "jsnext:main": "dist/custom-outputs-alt.jsnextmain.mjs",
+  "esmodule": "dist/custom-outputs-alt.esmodule.mjs",
+  "scripts": {
+    "build": "microbundle -f modern,es,umd,cjs"
+  }
+}

--- a/test/fixtures/custom-outputs-alt/src/index.js
+++ b/test/fixtures/custom-outputs-alt/src/index.js
@@ -1,0 +1,5 @@
+import { two } from './two';
+
+export default async function(...args) {
+	return [await two(...args), await two(...args)];
+}

--- a/test/fixtures/custom-outputs-alt/src/two.js
+++ b/test/fixtures/custom-outputs-alt/src/two.js
@@ -1,0 +1,3 @@
+export async function two(...args) {
+	return args.reduce((total, value) => total + value, 0);
+}

--- a/test/fixtures/custom-outputs/package.json
+++ b/test/fixtures/custom-outputs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "custom-outputs",
+  "main": "dist/custom-outputs.js",
+  "umd:main": "dist/custom-outputs.umdx.js",
+  "module": "dist/custom-outputs.modulex.mjs",
+  "exports": "./dist/custom-outputs.exportsx.mjs",
+  "scripts": {
+    "build": "microbundle -f modern,es,umd,cjs"
+  }
+}

--- a/test/fixtures/custom-outputs/src/index.js
+++ b/test/fixtures/custom-outputs/src/index.js
@@ -1,0 +1,5 @@
+import { two } from './two';
+
+export default async function(...args) {
+	return [await two(...args), await two(...args)];
+}

--- a/test/fixtures/custom-outputs/src/two.js
+++ b/test/fixtures/custom-outputs/src/two.js
@@ -1,0 +1,3 @@
+export async function two(...args) {
+	return args.reduce((total, value) => total + value, 0);
+}


### PR DESCRIPTION
Fixes #963 

Typo was from https://github.com/developit/microbundle/pull/950

We were missing tests for controlling the output filenames from `package.json` nearly entirely, both the common fields (`"main"`, `"module"`, etc.) and their alts (`"cjs:main"`, `"esmodule"`, etc.). This adds a test suite for both (though there's still a few untested fields, like nested `"exports"` and `"syntax.esmodule"` entry).