### PR TITLE
deps: upgrade rpt2 to latest v0.32.0 to fix monorepos

### DIFF
--- a/.changeset/green-foxes-poke.md
+++ b/.changeset/green-foxes-poke.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+deps: upgrade rpt2 to latest v0.32.0 to fix monorepos

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "microbundle",
-	"version": "0.14.2",
+	"version": "0.15.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "microbundle",
-			"version": "0.14.2",
+			"version": "0.15.0",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.12.10",
@@ -44,7 +44,7 @@
 				"rollup-plugin-bundle-size": "^1.0.3",
 				"rollup-plugin-postcss": "^4.0.0",
 				"rollup-plugin-terser": "^7.0.2",
-				"rollup-plugin-typescript2": "^0.29.0",
+				"rollup-plugin-typescript2": "^0.32.0",
 				"rollup-plugin-visualizer": "^5.6.0",
 				"sade": "^1.7.4",
 				"terser": "^5.7.0",
@@ -3220,15 +3220,6 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/@rollup/plugin-node-resolve/node_modules/resolve": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-			"dependencies": {
-				"is-core-module": "^2.1.0",
-				"path-parse": "^1.0.6"
-			}
-		},
 		"node_modules/@rollup/pluginutils": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -4015,15 +4006,6 @@
 			"engines": {
 				"node": ">=10",
 				"npm": ">=6"
-			}
-		},
-		"node_modules/babel-plugin-macros/node_modules/resolve": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-			"dependencies": {
-				"is-core-module": "^2.1.0",
-				"path-parse": "^1.0.6"
 			}
 		},
 		"node_modules/babel-plugin-transform-async-to-promises": {
@@ -7162,9 +7144,9 @@
 			}
 		},
 		"node_modules/find-cache-dir": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
 			"dependencies": {
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.2",
@@ -7172,6 +7154,9 @@
 			},
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
 			}
 		},
 		"node_modules/find-root": {
@@ -8122,11 +8107,14 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dependencies": {
 				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-data-descriptor": {
@@ -9667,16 +9655,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/jest-resolve/node_modules/resolve": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-			"dev": true,
-			"dependencies": {
-				"is-core-module": "^2.1.0",
-				"path-parse": "^1.0.6"
-			}
-		},
 		"node_modules/jest-resolve/node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10597,6 +10575,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -12894,9 +12873,9 @@
 			}
 		},
 		"node_modules/path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -15056,11 +15035,19 @@
 			"dev": true
 		},
 		"node_modules/resolve": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"dependencies": {
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.8.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/resolve-cwd": {
@@ -15295,15 +15282,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/rollup-plugin-postcss/node_modules/resolve": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-			"dependencies": {
-				"is-core-module": "^2.1.0",
-				"path-parse": "^1.0.6"
-			}
-		},
 		"node_modules/rollup-plugin-postcss/node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15327,34 +15305,69 @@
 			}
 		},
 		"node_modules/rollup-plugin-typescript2": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.29.0.tgz",
-			"integrity": "sha512-YytahBSZCIjn/elFugEGQR5qTsVhxhUwGZIsA9TmrSsC88qroGo65O5HZP/TTArH2dm0vUmYWhKchhwi2wL9bw==",
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.32.0.tgz",
+			"integrity": "sha512-sIiCObzETQagImlNa/xVZY2aKB/7w77EzKAzpmVkXZbDuso6PrW2hdQv6m4/UuMqnzqTFWGF4FPLbVuQISeYZw==",
 			"dependencies": {
-				"@rollup/pluginutils": "^3.1.0",
-				"find-cache-dir": "^3.3.1",
-				"fs-extra": "8.1.0",
-				"resolve": "1.17.0",
-				"tslib": "2.0.1"
+				"@rollup/pluginutils": "^4.1.2",
+				"find-cache-dir": "^3.3.2",
+				"fs-extra": "^10.0.0",
+				"resolve": "^1.20.0",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"rollup": ">=1.26.3",
+				"typescript": ">=2.4.0"
 			}
 		},
-		"node_modules/rollup-plugin-typescript2/node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+		"node_modules/rollup-plugin-typescript2/node_modules/@rollup/pluginutils": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
 			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
 			},
 			"engines": {
-				"node": ">=6 <7 || >=8"
+				"node": ">= 8.0.0"
 			}
 		},
-		"node_modules/rollup-plugin-typescript2/node_modules/tslib": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+		"node_modules/rollup-plugin-typescript2/node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+		},
+		"node_modules/rollup-plugin-typescript2/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/rollup-plugin-typescript2/node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/rollup-plugin-typescript2/node_modules/universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
 		},
 		"node_modules/rollup-plugin-visualizer": {
 			"version": "5.6.0",
@@ -16489,6 +16502,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/svgo": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -16846,9 +16870,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-			"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.17.1",
@@ -17086,6 +17110,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true,
 			"engines": {
 				"node": ">= 4.0.0"
 			}
@@ -20471,17 +20496,6 @@
 				"deepmerge": "^4.2.2",
 				"is-module": "^1.0.0",
 				"resolve": "^1.19.0"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.19.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-					"requires": {
-						"is-core-module": "^2.1.0",
-						"path-parse": "^1.0.6"
-					}
-				}
 			}
 		},
 		"@rollup/pluginutils": {
@@ -21147,17 +21161,6 @@
 				"@babel/runtime": "^7.12.5",
 				"cosmiconfig": "^7.0.0",
 				"resolve": "^1.19.0"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.19.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-					"requires": {
-						"is-core-module": "^2.1.0",
-						"path-parse": "^1.0.6"
-					}
-				}
 			}
 		},
 		"babel-plugin-transform-async-to-promises": {
@@ -23693,9 +23696,9 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
 			"requires": {
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.2",
@@ -24463,9 +24466,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"requires": {
 				"has": "^1.0.3"
 			}
@@ -25726,16 +25729,6 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"resolve": {
-					"version": "1.19.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-					"dev": true,
-					"requires": {
-						"is-core-module": "^2.1.0",
-						"path-parse": "^1.0.6"
-					}
-				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -26418,6 +26411,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -28220,9 +28214,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
 		"path-type": {
 			"version": "4.0.0",
@@ -29948,11 +29942,13 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"requires": {
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.8.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"resolve-cwd": {
@@ -30141,15 +30137,6 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
-				"resolve": {
-					"version": "1.19.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-					"requires": {
-						"is-core-module": "^2.1.0",
-						"path-parse": "^1.0.6"
-					}
-				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -30172,31 +30159,54 @@
 			}
 		},
 		"rollup-plugin-typescript2": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.29.0.tgz",
-			"integrity": "sha512-YytahBSZCIjn/elFugEGQR5qTsVhxhUwGZIsA9TmrSsC88qroGo65O5HZP/TTArH2dm0vUmYWhKchhwi2wL9bw==",
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.32.0.tgz",
+			"integrity": "sha512-sIiCObzETQagImlNa/xVZY2aKB/7w77EzKAzpmVkXZbDuso6PrW2hdQv6m4/UuMqnzqTFWGF4FPLbVuQISeYZw==",
 			"requires": {
-				"@rollup/pluginutils": "^3.1.0",
-				"find-cache-dir": "^3.3.1",
-				"fs-extra": "8.1.0",
-				"resolve": "1.17.0",
-				"tslib": "2.0.1"
+				"@rollup/pluginutils": "^4.1.2",
+				"find-cache-dir": "^3.3.2",
+				"fs-extra": "^10.0.0",
+				"resolve": "^1.20.0",
+				"tslib": "^2.4.0"
 			},
 			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+				"@rollup/pluginutils": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+					"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
 					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
+						"estree-walker": "^2.0.1",
+						"picomatch": "^2.2.2"
 					}
 				},
-				"tslib": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+				"estree-walker": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+					"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+				},
+				"fs-extra": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+					"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"jsonfile": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^2.0.0"
+					}
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
 				}
 			}
 		},
@@ -31133,6 +31143,11 @@
 				}
 			}
 		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+		},
 		"svgo": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -31416,9 +31431,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-			"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"tsutils": {
 			"version": "3.17.1",
@@ -31601,7 +31616,8 @@
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unquote": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"rollup-plugin-bundle-size": "^1.0.3",
 		"rollup-plugin-postcss": "^4.0.0",
 		"rollup-plugin-terser": "^7.0.2",
-		"rollup-plugin-typescript2": "^0.29.0",
+		"rollup-plugin-typescript2": "^0.32.0",
 		"rollup-plugin-visualizer": "^5.6.0",
 		"sade": "^1.7.4",
 		"terser": "^5.7.0",


### PR DESCRIPTION
## Intro

Hi 👋  , by way of introduction, I help maintain [`rollup-plugin-typescript2`](https://github.com/ezolenko/rollup-plugin-typescript2) and also formerly solo-maintained [TSDX](https://github.com/jaredpalmer/tsdx) for ~1.5 years (the creator hasn't been involved in years and his abusiveness was central to [me leaving OSS for over a year](https://twitter.com/agilgur5/status/1488621603944554496?s=20&t=rwq0kNT4T9BLBaZxJcMvVg)), so I'm very familiar with the internals of `microbundle` as well.

I was investigating https://github.com/ezolenko/rollup-plugin-typescript2/issues/295 and found that `microbundle` is on an older version of rpt2, causing several issues in this repo.

## Summary

Upgrade rpt2 to [v0.32.0](https://github.com/ezolenko/rollup-plugin-typescript2/releases/0.32.0) to fix various monorepo issues
- Fixes #808
- Fixes #931
- Possible fix for #845, but I'm not sure if that's _exactly_ a duplicate or not

## Details

- rpt2 [v0.30.0](https://github.com/ezolenko/rollup-plugin-typescript2/releases/0.30.0) supports compiling files outside of the project directory with no additional configuration (e.g. of `rootDir`) as it [upgraded its dep of `@rollup/pluginutils` to v4](https://github.com/ezolenko/rollup-plugin-typescript2/commit/c6f6e52933f520195364758cdf7fe8a371269611), which had a breaking change affecting `createFilter` in https://github.com/rollup/plugins/pull/517
  - essentially, the change to `@rollup/pluginutils` allows transforming files outside of the project dir

- rpt2 [v0.32.0](https://github.com/ezolenko/rollup-plugin-typescript2/releases/0.32.0) supports symlinks, such as with monorepos built w/ pnpm

- previously, microbundle was using rpt2 [v0.29.0](https://github.com/developit/microbundle/blob/555088d17c97860a51ce43808853f4d4f0146a4c/package.json#L111), which is about ~1.5 years out-of-date

## References

- Root cause analysis for compiling files outside of project dir: https://github.com/ezolenko/rollup-plugin-typescript2/issues/295#issuecomment-1139994454 which references #808 and duplicated https://github.com/ezolenko/rollup-plugin-typescript2/issues/216#issuecomment-1140024487
- Root cause analysis for symlink issues: https://github.com/ezolenko/rollup-plugin-typescript2/issues/234#issuecomment-1139202740
  - PR that fixed it: https://github.com/ezolenko/rollup-plugin-typescript2/pull/332
  
## Testing

It doesn't look like `microbundle`'s fixtures support monorepos yet (would require setting up symlinks or `pnpm` etc), so as a result I didn't add a whole test suite for that which would've made this PR significantly more complex and involved in the internals of the testing set-up.
Once I set-up an integration test for this in rpt2, I could contribute a similar fixture downstream here, but it may require a different CI workflow to not break the existing test set-up