### PR TITLE
PoC: SWC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
 				"rollup": "^2.35.1",
 				"rollup-plugin-bundle-size": "^1.0.3",
 				"rollup-plugin-postcss": "^4.0.0",
+				"rollup-plugin-swc3": "^0.3.0",
 				"rollup-plugin-terser": "^7.0.2",
 				"rollup-plugin-typescript2": "^0.32.0",
 				"rollup-plugin-visualizer": "^5.6.0",
@@ -3259,6 +3260,245 @@
 				"ejs": "^3.1.6",
 				"json5": "^2.2.0",
 				"magic-string": "^0.25.0"
+			}
+		},
+		"node_modules/@swc/core": {
+			"version": "1.2.215",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.215.tgz",
+			"integrity": "sha512-Dm6q1wP4OvG5DOHC9JQC4wAjIH4Pz8K4MfVrluojD7epDN97j2md6/QbMaL5Zcu24SsAuib8BYF4j9VelLrvtw==",
+			"peer": true,
+			"bin": {
+				"swcx": "run_swcx.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/swc"
+			},
+			"optionalDependencies": {
+				"@swc/core-android-arm-eabi": "1.2.216",
+				"@swc/core-android-arm64": "1.2.216",
+				"@swc/core-darwin-arm64": "1.2.216",
+				"@swc/core-darwin-x64": "1.2.216",
+				"@swc/core-freebsd-x64": "1.2.216",
+				"@swc/core-linux-arm-gnueabihf": "1.2.216",
+				"@swc/core-linux-arm64-gnu": "1.2.216",
+				"@swc/core-linux-arm64-musl": "1.2.216",
+				"@swc/core-linux-x64-gnu": "1.2.216",
+				"@swc/core-linux-x64-musl": "1.2.216",
+				"@swc/core-win32-arm64-msvc": "1.2.216",
+				"@swc/core-win32-ia32-msvc": "1.2.216",
+				"@swc/core-win32-x64-msvc": "1.2.216"
+			}
+		},
+		"node_modules/@swc/core-android-arm-eabi": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.216.tgz",
+			"integrity": "sha512-V8iNfyaiNROZ+rfCzuoYBUYxlJ1yIkX3w0av54eCLigRktBDozUtYEbE0I/L9/WX3JDMKxMSt9cAjyMd8tmjyA==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-android-arm64": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.216.tgz",
+			"integrity": "sha512-4N2dq2JQQTVX1rLR7p/n1ag0T9N1oRp35H7yci2bFxWbLfVvb7qShathHsr2XzkBhgmtc32zWnPPDIzolrew2g==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-darwin-arm64": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.216.tgz",
+			"integrity": "sha512-rCof/23rLM0UEjrGhD9pqv0o50c5FMC7YCJGr4GP98iu4pGb0kgDlfu5EAO8wpXG2tMut3OHiQSefCWbtlygPA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-darwin-x64": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.216.tgz",
+			"integrity": "sha512-UarehjeGDxwfDmyR8egAVntkKitIe68v2NABQFBtnFdjt0vixWbrSKFsrFxOZZVIb+S2NTxdk3l4An5Nr0MK8A==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-freebsd-x64": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.216.tgz",
+			"integrity": "sha512-+R9cKtvSCVEEqsjnyFDmK5iXub9AlDliWLgx6aMb5HtxgIsd7V+5sr0SXXLk5/1x0Fjjo8KURw3Aw/0hlElMqg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm-gnueabihf": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.216.tgz",
+			"integrity": "sha512-ZUJDodTpfB9hlpOpUhLKAKrtZW4pzNAggj6OHjqR1Xm62Qq1wda0Kz4nx+9ltXFdnDwA3xo3ETILah4fqugVJQ==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-gnu": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.216.tgz",
+			"integrity": "sha512-OhL9+FHjnOAcU/mpKEx6UP4Rq7xYeUBi2+DEO/e7b7bLOjnOoySbUp1A6ytVH+DMLPRdc8gl8fmW3Ua40LZIwg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-musl": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.216.tgz",
+			"integrity": "sha512-CqocVXV2r9CUDYz0yuJAh3d8snXAztYps/Svsh9dBmXhB55IdaxcVPpxqThLlQStuzkI+8V3arxrWbbNtNd99g==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-gnu": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.216.tgz",
+			"integrity": "sha512-Lz7KKhWsg1LrZfcqxPiRhn6+j34TsVIIyCdxv497pSrY8ZvxST1JizEC7Rk48fHa+OkS9AVkoS3tElTX2oE7pg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-musl": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.216.tgz",
+			"integrity": "sha512-hOQ6/++C5DZrcywKJtpQKbZHezTDUEsH4eDc1UJh6tQPWRZFPSJcFOvemJi1e7PrdFjQINamqnAlkisNCYjTmA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-arm64-msvc": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.216.tgz",
+			"integrity": "sha512-W4K2k4tCOXGCk+DWyBvi0Cal2trVTCXaAGwRUpHcGjwGdxT7q3uCIoNoeCWdy6/5b/CnQDQ+8kWuD4NESjgt3A==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-ia32-msvc": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.216.tgz",
+			"integrity": "sha512-pHoCPbW8Dj0MSxtO9BPzT+AkNopapYnRBGqBnUS5pJjjRj/pnvWkvwaG95IZnklHnw8fPeuFpaGc+B2PYJuFEA==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-x64-msvc": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.216.tgz",
+			"integrity": "sha512-ZDKEvCH7UGiCa93dMwzl01vKgSygf4FF/GszZEHL6CDY8YRMABycLDB0so66nOPOcSqfxSHr3eFB3KtY5OMrEA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@types/babel__core": {
@@ -10452,6 +10692,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/joycon": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+			"integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10570,6 +10818,11 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/jsonc-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
+			"integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg=="
 		},
 		"node_modules/jsonfile": {
 			"version": "4.0.0",
@@ -11320,6 +11573,11 @@
 				"yallist": "^2.1.2"
 			}
 		},
+		"node_modules/lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+		},
 		"node_modules/magic-string": {
 			"version": "0.25.7",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -11384,6 +11642,17 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/marked": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
+			"integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/maxmin": {
@@ -15293,6 +15562,42 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/rollup-plugin-swc3": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-swc3/-/rollup-plugin-swc3-0.3.0.tgz",
+			"integrity": "sha512-ZQK2XxYxSspmT8j6/Y4CaxRxAlZHbNnxI+m+yJ5I87ZLp5uH7CYL4hFlJk1jkcZ+Q2QC19jIg7AClB/7+XFljw==",
+			"dependencies": {
+				"@rollup/pluginutils": "^4.2.1",
+				"deepmerge": "^4.2.2",
+				"joycon": "^3.1.1",
+				"jsonc-parser": "^3.0.0",
+				"typedoc": "^0.22.15"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.165",
+				"rollup": "^2.0.0"
+			}
+		},
+		"node_modules/rollup-plugin-swc3/node_modules/@rollup/pluginutils": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+			"dependencies": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/rollup-plugin-swc3/node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+		},
 		"node_modules/rollup-plugin-terser": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -15784,6 +16089,16 @@
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true,
 			"optional": true
+		},
+		"node_modules/shiki": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+			"integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+			"dependencies": {
+				"jsonc-parser": "^3.0.0",
+				"vscode-oniguruma": "^1.6.1",
+				"vscode-textmate": "5.2.0"
+			}
 		},
 		"node_modules/side-channel": {
 			"version": "1.0.2",
@@ -17033,6 +17348,64 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"node_modules/typedoc": {
+			"version": "0.22.18",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+			"integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+			"dependencies": {
+				"glob": "^8.0.3",
+				"lunr": "^2.3.9",
+				"marked": "^4.0.16",
+				"minimatch": "^5.1.0",
+				"shiki": "^0.10.1"
+			},
+			"bin": {
+				"typedoc": "bin/typedoc"
+			},
+			"engines": {
+				"node": ">= 12.10.0"
+			},
+			"peerDependencies": {
+				"typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
+			}
+		},
+		"node_modules/typedoc/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/typedoc/node_modules/glob": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+			"integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/typedoc/node_modules/minimatch": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+			"integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
@@ -17298,6 +17671,16 @@
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
 			}
+		},
+		"node_modules/vscode-oniguruma": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+			"integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
+		},
+		"node_modules/vscode-textmate": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
 		},
 		"node_modules/w3c-hr-time": {
 			"version": "1.0.2",
@@ -20535,6 +20918,118 @@
 				"json5": "^2.2.0",
 				"magic-string": "^0.25.0"
 			}
+		},
+		"@swc/core": {
+			"version": "1.2.215",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.215.tgz",
+			"integrity": "sha512-Dm6q1wP4OvG5DOHC9JQC4wAjIH4Pz8K4MfVrluojD7epDN97j2md6/QbMaL5Zcu24SsAuib8BYF4j9VelLrvtw==",
+			"peer": true,
+			"requires": {
+				"@swc/core-android-arm-eabi": "1.2.216",
+				"@swc/core-android-arm64": "1.2.216",
+				"@swc/core-darwin-arm64": "1.2.216",
+				"@swc/core-darwin-x64": "1.2.216",
+				"@swc/core-freebsd-x64": "1.2.216",
+				"@swc/core-linux-arm-gnueabihf": "1.2.216",
+				"@swc/core-linux-arm64-gnu": "1.2.216",
+				"@swc/core-linux-arm64-musl": "1.2.216",
+				"@swc/core-linux-x64-gnu": "1.2.216",
+				"@swc/core-linux-x64-musl": "1.2.216",
+				"@swc/core-win32-arm64-msvc": "1.2.216",
+				"@swc/core-win32-ia32-msvc": "1.2.216",
+				"@swc/core-win32-x64-msvc": "1.2.216"
+			}
+		},
+		"@swc/core-android-arm-eabi": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.216.tgz",
+			"integrity": "sha512-V8iNfyaiNROZ+rfCzuoYBUYxlJ1yIkX3w0av54eCLigRktBDozUtYEbE0I/L9/WX3JDMKxMSt9cAjyMd8tmjyA==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-android-arm64": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.216.tgz",
+			"integrity": "sha512-4N2dq2JQQTVX1rLR7p/n1ag0T9N1oRp35H7yci2bFxWbLfVvb7qShathHsr2XzkBhgmtc32zWnPPDIzolrew2g==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-darwin-arm64": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.216.tgz",
+			"integrity": "sha512-rCof/23rLM0UEjrGhD9pqv0o50c5FMC7YCJGr4GP98iu4pGb0kgDlfu5EAO8wpXG2tMut3OHiQSefCWbtlygPA==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-darwin-x64": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.216.tgz",
+			"integrity": "sha512-UarehjeGDxwfDmyR8egAVntkKitIe68v2NABQFBtnFdjt0vixWbrSKFsrFxOZZVIb+S2NTxdk3l4An5Nr0MK8A==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-freebsd-x64": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.216.tgz",
+			"integrity": "sha512-+R9cKtvSCVEEqsjnyFDmK5iXub9AlDliWLgx6aMb5HtxgIsd7V+5sr0SXXLk5/1x0Fjjo8KURw3Aw/0hlElMqg==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-linux-arm-gnueabihf": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.216.tgz",
+			"integrity": "sha512-ZUJDodTpfB9hlpOpUhLKAKrtZW4pzNAggj6OHjqR1Xm62Qq1wda0Kz4nx+9ltXFdnDwA3xo3ETILah4fqugVJQ==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-linux-arm64-gnu": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.216.tgz",
+			"integrity": "sha512-OhL9+FHjnOAcU/mpKEx6UP4Rq7xYeUBi2+DEO/e7b7bLOjnOoySbUp1A6ytVH+DMLPRdc8gl8fmW3Ua40LZIwg==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-linux-arm64-musl": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.216.tgz",
+			"integrity": "sha512-CqocVXV2r9CUDYz0yuJAh3d8snXAztYps/Svsh9dBmXhB55IdaxcVPpxqThLlQStuzkI+8V3arxrWbbNtNd99g==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-linux-x64-gnu": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.216.tgz",
+			"integrity": "sha512-Lz7KKhWsg1LrZfcqxPiRhn6+j34TsVIIyCdxv497pSrY8ZvxST1JizEC7Rk48fHa+OkS9AVkoS3tElTX2oE7pg==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-linux-x64-musl": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.216.tgz",
+			"integrity": "sha512-hOQ6/++C5DZrcywKJtpQKbZHezTDUEsH4eDc1UJh6tQPWRZFPSJcFOvemJi1e7PrdFjQINamqnAlkisNCYjTmA==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-win32-arm64-msvc": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.216.tgz",
+			"integrity": "sha512-W4K2k4tCOXGCk+DWyBvi0Cal2trVTCXaAGwRUpHcGjwGdxT7q3uCIoNoeCWdy6/5b/CnQDQ+8kWuD4NESjgt3A==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-win32-ia32-msvc": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.216.tgz",
+			"integrity": "sha512-pHoCPbW8Dj0MSxtO9BPzT+AkNopapYnRBGqBnUS5pJjjRj/pnvWkvwaG95IZnklHnw8fPeuFpaGc+B2PYJuFEA==",
+			"optional": true,
+			"peer": true
+		},
+		"@swc/core-win32-x64-msvc": {
+			"version": "1.2.216",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.216.tgz",
+			"integrity": "sha512-ZDKEvCH7UGiCa93dMwzl01vKgSygf4FF/GszZEHL6CDY8YRMABycLDB0so66nOPOcSqfxSHr3eFB3KtY5OMrEA==",
+			"optional": true,
+			"peer": true
 		},
 		"@types/babel__core": {
 			"version": "7.1.12",
@@ -26306,6 +26801,11 @@
 				}
 			}
 		},
+		"joycon": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+			"integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -26406,6 +26906,11 @@
 			"requires": {
 				"minimist": "^1.2.5"
 			}
+		},
+		"jsonc-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
+			"integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg=="
 		},
 		"jsonfile": {
 			"version": "4.0.0",
@@ -27000,6 +27505,11 @@
 				"yallist": "^2.1.2"
 			}
 		},
+		"lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+		},
 		"magic-string": {
 			"version": "0.25.7",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -27052,6 +27562,11 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
+		},
+		"marked": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
+			"integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw=="
 		},
 		"maxmin": {
 			"version": "2.1.0",
@@ -30147,6 +30662,34 @@
 				}
 			}
 		},
+		"rollup-plugin-swc3": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-swc3/-/rollup-plugin-swc3-0.3.0.tgz",
+			"integrity": "sha512-ZQK2XxYxSspmT8j6/Y4CaxRxAlZHbNnxI+m+yJ5I87ZLp5uH7CYL4hFlJk1jkcZ+Q2QC19jIg7AClB/7+XFljw==",
+			"requires": {
+				"@rollup/pluginutils": "^4.2.1",
+				"deepmerge": "^4.2.2",
+				"joycon": "^3.1.1",
+				"jsonc-parser": "^3.0.0",
+				"typedoc": "^0.22.15"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+					"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+					"requires": {
+						"estree-walker": "^2.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"estree-walker": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+					"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+				}
+			}
+		},
 		"rollup-plugin-terser": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -30536,6 +31079,16 @@
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true,
 			"optional": true
+		},
+		"shiki": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+			"integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+			"requires": {
+				"jsonc-parser": "^3.0.0",
+				"vscode-oniguruma": "^1.6.1",
+				"vscode-textmate": "5.2.0"
+			}
 		},
 		"side-channel": {
 			"version": "1.0.2",
@@ -31562,6 +32115,48 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"typedoc": {
+			"version": "0.22.18",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+			"integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+			"requires": {
+				"glob": "^8.0.3",
+				"lunr": "^2.3.9",
+				"marked": "^4.0.16",
+				"minimatch": "^5.1.0",
+				"shiki": "^0.10.1"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "8.0.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+					"integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^5.0.1",
+						"once": "^1.3.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+					"integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				}
+			}
+		},
 		"typescript": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
@@ -31774,6 +32369,16 @@
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
 			}
+		},
+		"vscode-oniguruma": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+			"integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
+		},
+		"vscode-textmate": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
 		},
 		"w3c-hr-time": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"rollup": "^2.35.1",
 		"rollup-plugin-bundle-size": "^1.0.3",
 		"rollup-plugin-postcss": "^4.0.0",
+		"rollup-plugin-swc3": "^0.3.0",
 		"rollup-plugin-terser": "^7.0.2",
 		"rollup-plugin-typescript2": "^0.32.0",
 		"rollup-plugin-visualizer": "^5.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,15 @@ import { getConfigFromPkgJson, getName } from './lib/package-info';
 import { shouldCssModules, cssModulesConfig } from './lib/css-modules';
 import { EOL } from 'os';
 
+const swc = (() => {
+	try {
+		require('@swc/core');
+		return require('rollup-plugin-swc3').default;
+	} catch (e) {
+		return null;
+	}
+})();
+
 // Extensions to use when resolving modules
 const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.es6', '.es', '.mjs'];
 
@@ -531,6 +540,14 @@ function createConfig(options, entry, format, writeMeta) {
 							map: null,
 						}),
 					},
+					swc &&
+						swc({
+							sourceMaps: true,
+							jsc: {
+								target: 'es2018',
+							},
+						}),
+					!swc &&
 					(useTypescript || emitDeclaration) &&
 						typescript({
 							cwd: options.cwd,
@@ -564,6 +581,7 @@ function createConfig(options, entry, format, writeMeta) {
 							},
 						}),
 					// if defines is not set, we shouldn't run babel through node_modules
+					!swc &&
 					isTruthy(defines) &&
 						babel({
 							babelHelpers: 'bundled',
@@ -578,6 +596,7 @@ function createConfig(options, entry, format, writeMeta) {
 								],
 							],
 						}),
+					!swc &&
 					customBabel()({
 						babelHelpers: 'bundled',
 						extensions: EXTENSIONS,


### PR DESCRIPTION
Hi! Was going to write this as a comment but I thought a functional PR would be a nicer way to make a proposal.

A cleaned up version of this could resolve #943 in a way that didn't involve either inflating microbundle's size or completely rewriting the whole library around SWC.

Basically, it looks for the `@swc/core` dependency, and if it's found, assumes that the user wants to use `swc` instead of babel or typescript. But `@swc/core` _isn't_ a dependency of microbundle. Which means most users can just continue using microbundle as is and not be affected. People who want to try microbundle out with SWC just have to install `@swc/core` which has the nice properties of being natural and intuitive for people who do want to use SWC, and unusual for anyone else.

It _does_ add `rollup-plugin-swc3` as a proper dependency of microbundle, because that's just a small javascript module, and it seems like the sort of thing microbundle should save users from having to worry about (whether they should use `rollup-plugin-swc`, `rollup-plugin-swc2` or `rollup-plugin-swc3`, and how to configure the chosen package).

I tried on a small typescript project with no dependencies, with an output of about 4kb. With swc it took about 6s, without it took 21s.

Some things that should be addressed before this PoC were to be shippable (I didn't attempt to do this because I am not very knowledgeable about microbundle, babel, or SWC):

1. there should be a CLI flag to let people who have `@swc/core` installed for unrelated reasons to opt out (e.g. `--swc false`)
2. it should be configured properly to output the right style in various configurations. In this PR I just hardcoded `target: 'es2018'` fairly arbitrarily. It should also respect any existing swc config detected, if present.
3. docs!
4. the rollup-plugin-swc3 minifier should be used instead of rollup-plugin-terser - probably a bunch of the perf benefits are being negated by not doing this
5. (maybe) rely on rollup-plugin-swc3 to emit typescript declaration files too. Might or might not be faster 🤷 
6. prettier/code cleanup etc. I deliberately avoided formatting `src/index.js` to make the diff easy to ready, but probably some refactoring should be done

If this goes well and people start using it, after a few months of the community helping flush out any issues, maybe something like the solution suggested by @developit in https://github.com/developit/microbundle/issues/943#issuecomment-1146963352 could be done with SWC. But the advantage of doing this way first is that we could likely do _exactly_ the same thing with [rollup-plugin-esbuild](https://www.npmjs.com/package/rollup-plugin-esbuild), and effectively support users with both. The community seems pretty evenly split between the two, and they're both an order of magnitude faster than typescript or babel.