### PR TITLE
chore: Silence Rollup's `this is undefined` warnings

### DIFF
--- a/.changeset/swift-plums-fix.md
+++ b/.changeset/swift-plums-fix.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Silence Rollup's noisy (and usually harmless) `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten.` warnings

--- a/src/index.js
+++ b/src/index.js
@@ -473,7 +473,7 @@ function createConfig(options, entry, format, writeMeta) {
 							`\n ↳ to depend on a module via import/require, install it to "dependencies".`,
 					);
 					return;
-				}
+				} else if (warning.code === 'THIS_IS_UNDEFINED') return;
 
 				warn(warning);
 			},


### PR DESCRIPTION
Closes #682

Re:https://github.com/developit/microbundle/issues/682#issuecomment-1221769448, the warning is silenced globally.

I'm a little apprehensive about not limiting this to `node_modules/` though, as it could warn of a legitimate issue.