### PR TITLE
Fix `mangle.json` indentation style not preserved

### DIFF
--- a/.changeset/gold-berries-march.md
+++ b/.changeset/gold-berries-march.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Fix indentation style in `mangle.json` not preserved

--- a/src/index.js
+++ b/src/index.js
@@ -408,9 +408,11 @@ function createConfig(options, entry, format, writeMeta) {
 
 	let endsWithNewLine = false;
 
+	let nameCacheIndentTabs = false;
 	function loadNameCache() {
 		try {
 			const data = fs.readFileSync(getNameCachePath(), 'utf8');
+			nameCacheIndentTabs = /^\t+/gm.test(data);
 			endsWithNewLine = data.endsWith(EOL);
 			nameCache = JSON.parse(data);
 			// mangle.json can contain a "minify" field, same format as the pkg.mangle:
@@ -628,7 +630,11 @@ function createConfig(options, entry, format, writeMeta) {
 							writeBundle() {
 								if (writeMeta && nameCache) {
 									let filename = getNameCachePath();
-									let json = JSON.stringify(nameCache, null, 2);
+									let json = JSON.stringify(
+										nameCache,
+										null,
+										nameCacheIndentTabs ? '\t' : 2,
+									);
 									if (endsWithNewLine) json += EOL;
 									fs.writeFile(filename, json, () => {});
 								}


### PR DESCRIPTION
This preserves tab-style indentation in `mangle.json`.