### PR TITLE
fix: disable tree-shaking via PURE annotations when compression is disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -481,6 +481,7 @@ function createConfig(options, entry, format, writeMeta) {
 			},
 
 			treeshake: {
+				annotations: options.compress,
 				propertyReadSideEffects: false,
 			},
 


### PR DESCRIPTION
When building a library, "pure" comments are often added to various bits and pieces to ensure tree-shaking works properly in the destination bundle. Compression via terser will automatically drop these hints in some cases, so disabling compression serves the purpose of leaving total minification up to the destination bundler.

At the moment, `rollup` takes these pure comments into account as well when bundling which can lead to early-dropping of statements that are meant to be dropped _later_ in the destination bundler. We should disable "pure" comment-related treeshaking in microbundle when compression is turned off to ensure this use case works as expected.

For example, here's a use case which involves setting `displayName` on a component in a way that if the component is tree-shaken, the displayName goes away as well:

```tsx
const Foo = (props) => <div {...props} />

/*#​__PURE__*/Object.assign(Foo, { displayName: 'Foo' });
```