### PR TITLE
chore: add eta js to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ Here's what's coming up for Microbundle:
 - [@studio-freight/tempus](https://github.com/studio-freight/tempus) One rAF to rule them all.
 - [@studio-freight/hamo](https://github.com/studio-freight/hamo) Collection of React hooks.
 - [glTF Transform](https://github.com/donmccurdy/glTF-Transform) Library for working with .gltf and .glb 3D models.
+- [eta](https://github.com/eta-dev/eta) Lightweight, powerful, pluggable embedded JS template engine
 
 ## 🥂 License
 


### PR DESCRIPTION
I made a PR for eta js, and I discovered it was build with microbundle :)