### PR TITLE
chore: remove `brazillian-utils` from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,6 @@ Here's what's coming up for Microbundle:
 - [Microenvi](https://github.com/fwilkerson/microenvi) Bundle, serve, and hot reload with one command.
 - [Theme UI](https://github.com/system-ui/theme-ui) Build consistent, themeable React apps based on constraint-based design principles.
 - [react-recomponent](https://github.com/philipp-spiess/react-recomponent) Reason-style reducer components for React using ES6 classes.
-- [brazilian-utils](https://github.com/brazilian-utils/brazilian-utils) Utils library for specific Brazilian businesses.
 - [react-hooks-lib](https://github.com/beizhedenglong/react-hooks-lib) A set of reusable react hooks.
 - [mdx-deck-live-code](https://github.com/JReinhold/mdx-deck-live-code) A library for [mdx-deck](https://github.com/jxnblk/mdx-deck) to do live React and JS coding directly in slides.
 - [react-router-ext](https://github.com/ri7nz/react-router-ext) An Extended [react-router-dom](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-dom) with simple usage.


### PR DESCRIPTION
Found out that `brazilian-utils` [isn't using microbundle anymore ](https://github.com/search?q=repo%3Abrazilian-utils%2Fbrazilian-utils%20microbundle&type=code) 😞 