### PR TITLE
chore: add licenses badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 <h1 align="center">
 	Microbundle
-	<a href="https://www.npmjs.org/package/microbundle"><img src="https://img.shields.io/npm/v/microbundle.svg?style=flat" alt="npm"></a> <a href="https://travis-ci.org/developit/microbundle"><img src="https://travis-ci.org/developit/microbundle.svg?branch=master" alt="travis"></a>
+	<a href="https://www.npmjs.org/package/microbundle"><img src="https://img.shields.io/npm/v/microbundle.svg?style=flat" alt="npm"></a> <a href="https://travis-ci.org/developit/microbundle"><img src="https://travis-ci.org/developit/microbundle.svg?branch=master" alt="travis"></a> <a href="https://licenses.dev/npm/microbundle"><img src="https://licenses.dev/b/npm/microbundle" alt="licenses" /></a>
 </h1>
 <p align="center">The <strong>zero-configuration</strong> bundler for <em>tiny modules</em>, powered by <a href="https://github.com/rollup/rollup">Rollup</a>.</p>
 


### PR DESCRIPTION
This service recursively checks/lists all licenses within a package's dependency graph. I remember there being a fair number of pieces involved here so was happy to see that all 400+ licenses involved are green!

Also, hello! 👋 