### PR TITLE
Bump vulnerable package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "microbundle",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "microbundle",
-			"version": "0.15.0",
+			"version": "0.15.1",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.12.10",
+				"@babel/core": "^7.24.4",
 				"@babel/plugin-proposal-class-properties": "7.12.1",
 				"@babel/plugin-syntax-import-meta": "^7.10.4",
 				"@babel/plugin-syntax-jsx": "^7.12.1",
@@ -81,6 +81,18 @@
 				"strip-ansi": "^6.0.0"
 			}
 		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@babel/cli": {
 			"version": "7.12.10",
 			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.12.10.tgz",
@@ -146,122 +158,79 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
 			"dependencies": {
-				"@babel/highlight": "^7.10.4"
-			}
-		},
-		"node_modules/@babel/compat-data": {
-			"version": "7.12.7",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
-			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw=="
-		},
-		"node_modules/@babel/core": {
-			"version": "7.12.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
-			"integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.10",
-				"@babel/helper-module-transforms": "^7.12.1",
-				"@babel/helpers": "^7.12.5",
-				"@babel/parser": "^7.12.10",
-				"@babel/template": "^7.12.7",
-				"@babel/traverse": "^7.12.10",
-				"@babel/types": "^7.12.10",
-				"convert-source-map": "^1.7.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.1",
-				"json5": "^2.1.2",
-				"lodash": "^4.17.19",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
+				"@babel/highlight": "^7.24.2",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/core/node_modules/@babel/generator": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-			"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
-			"dependencies": {
-				"@babel/types": "^7.12.11",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
+		"node_modules/@babel/compat-data": {
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+			"integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/core/node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-			"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+		"node_modules/@babel/core": {
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
+			"integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
 			"dependencies": {
-				"@babel/types": "^7.12.11"
-			}
-		},
-		"node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/core/node_modules/@babel/parser": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-			"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
-			"bin": {
-				"parser": "bin/babel-parser.js"
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.24.2",
+				"@babel/generator": "^7.24.4",
+				"@babel/helper-compilation-targets": "^7.23.6",
+				"@babel/helper-module-transforms": "^7.23.3",
+				"@babel/helpers": "^7.24.4",
+				"@babel/parser": "^7.24.4",
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
 			}
 		},
-		"node_modules/@babel/core/node_modules/@babel/template": {
-			"version": "7.12.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-			"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.12.7",
-				"@babel/types": "^7.12.7"
-			}
+		"node_modules/@babel/core/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
 		},
-		"node_modules/@babel/core/node_modules/@babel/traverse": {
-			"version": "7.12.10",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-			"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.10",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.10",
-				"@babel/types": "^7.12.10",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
-			}
-		},
-		"node_modules/@babel/core/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-			"integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
+			"integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
 			"dependencies": {
-				"@babel/types": "^7.10.4",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
-				"source-map": "^0.5.0"
+				"@babel/types": "^7.24.0",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jsesc": "^2.5.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-annotate-as-pure": {
@@ -270,21 +239,6 @@
 			"integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
 			"dependencies": {
 				"@babel/types": "^7.12.10"
-			}
-		},
-		"node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -315,64 +269,41 @@
 				"@babel/types": "^7.12.11"
 			}
 		},
-		"node_modules/@babel/helper-builder-react-jsx-experimental/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-builder-react-jsx-experimental/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
-			"integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
 			"dependencies": {
-				"@babel/compat-data": "^7.12.5",
-				"@babel/helper-validator-option": "^7.12.1",
-				"browserslist": "^4.14.5",
-				"semver": "^5.5.0"
-			}
-		},
-		"node_modules/@babel/helper-compilation-targets/node_modules/browserslist": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-			"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
-			"dependencies": {
-				"caniuse-lite": "^1.0.30001165",
-				"colorette": "^1.2.1",
-				"electron-to-chromium": "^1.3.621",
-				"escalade": "^3.1.1",
-				"node-releases": "^1.1.67"
-			},
-			"bin": {
-				"browserslist": "cli.js"
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-validator-option": "^7.23.5",
+				"browserslist": "^4.22.2",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
 			},
 			"engines": {
-				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-compilation-targets/node_modules/caniuse-lite": {
-			"version": "1.0.30001168",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-			"integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
+		"node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
 		},
-		"node_modules/@babel/helper-compilation-targets/node_modules/electron-to-chromium": {
-			"version": "1.3.628",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.628.tgz",
-			"integrity": "sha512-fmhO4YGo/kapy+xL9Eq/cZwDASaTHZu3psIFYo4yc+RY1LzbZr84xjKlDImDrlrmWhOxsrDi98nX097U/xK/cQ=="
+		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
 		},
-		"node_modules/@babel/helper-compilation-targets/node_modules/node-releases": {
-			"version": "1.1.67",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
+		"node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
 			"version": "7.12.1",
@@ -405,19 +336,12 @@
 				"lodash": "^4.17.19"
 			}
 		},
-		"node_modules/@babel/helper-define-map/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-define-map/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
+		"node_modules/@babel/helper-environment-visitor": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-explode-assignable-expression": {
@@ -428,45 +352,27 @@
 				"@babel/types": "^7.12.1"
 			}
 		},
-		"node_modules/@babel/helper-explode-assignable-expression/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-explode-assignable-expression/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dependencies": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"node_modules/@babel/helper-get-function-arity": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-			"dependencies": {
-				"@babel/types": "^7.10.4"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
-			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dependencies": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
@@ -477,119 +383,34 @@
 				"@babel/types": "^7.12.7"
 			}
 		},
-		"node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+			"integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
 			"dependencies": {
-				"@babel/types": "^7.12.5"
-			}
-		},
-		"node_modules/@babel/helper-module-imports/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
+				"@babel/types": "^7.24.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+			"integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.12.1",
-				"@babel/helper-replace-supers": "^7.12.1",
-				"@babel/helper-simple-access": "^7.12.1",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.1",
-				"@babel/types": "^7.12.1",
-				"lodash": "^4.17.19"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms/node_modules/@babel/generator": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-			"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
-			"dependencies": {
-				"@babel/types": "^7.12.11",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-			"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
-			"dependencies": {
-				"@babel/types": "^7.12.11"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms/node_modules/@babel/parser": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-			"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
-			"bin": {
-				"parser": "bin/babel-parser.js"
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.20"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
-		},
-		"node_modules/@babel/helper-module-transforms/node_modules/@babel/traverse": {
-			"version": "7.12.10",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-			"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.10",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.10",
-				"@babel/types": "^7.12.10",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms/node_modules/@babel/types/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
 			"version": "7.12.10",
@@ -597,21 +418,6 @@
 			"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
 			"dependencies": {
 				"@babel/types": "^7.12.10"
-			}
-		},
-		"node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
@@ -629,21 +435,6 @@
 				"@babel/types": "^7.12.1"
 			}
 		},
-		"node_modules/@babel/helper-remap-async-to-generator/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-remap-async-to-generator/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
 		"node_modules/@babel/helper-replace-supers": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
@@ -655,87 +446,15 @@
 				"@babel/types": "^7.12.11"
 			}
 		},
-		"node_modules/@babel/helper-replace-supers/node_modules/@babel/generator": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-			"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+		"node_modules/@babel/helper-simple-access": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
 			"dependencies": {
-				"@babel/types": "^7.12.11",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
-			}
-		},
-		"node_modules/@babel/helper-replace-supers/node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-			"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
-			"dependencies": {
-				"@babel/types": "^7.12.11"
-			}
-		},
-		"node_modules/@babel/helper-replace-supers/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-replace-supers/node_modules/@babel/parser": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-			"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
-			"bin": {
-				"parser": "bin/babel-parser.js"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/helper-replace-supers/node_modules/@babel/traverse": {
-			"version": "7.12.10",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-			"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.10",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.10",
-				"@babel/types": "^7.12.10",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
-			}
-		},
-		"node_modules/@babel/helper-replace-supers/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"node_modules/@babel/helper-simple-access": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
-			"dependencies": {
-				"@babel/types": "^7.12.1"
-			}
-		},
-		"node_modules/@babel/helper-simple-access/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
@@ -746,38 +465,40 @@
 				"@babel/types": "^7.12.1"
 			}
 		},
-		"node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
+		"node_modules/@babel/helper-split-export-declaration": {
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
+				"@babel/types": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-			"dependencies": {
-				"@babel/types": "^7.10.4"
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+			"integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
-			"integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw=="
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
 			"version": "7.12.3",
@@ -791,83 +512,30 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
-			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
+			"integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
 			"dependencies": {
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.5",
-				"@babel/types": "^7.12.5"
-			}
-		},
-		"node_modules/@babel/helpers/node_modules/@babel/generator": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-			"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
-			"dependencies": {
-				"@babel/types": "^7.12.11",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
-			}
-		},
-		"node_modules/@babel/helpers/node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-			"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
-			"dependencies": {
-				"@babel/types": "^7.12.11"
-			}
-		},
-		"node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/helpers/node_modules/@babel/parser": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-			"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
-			"bin": {
-				"parser": "bin/babel-parser.js"
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0"
 			},
 			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/helpers/node_modules/@babel/traverse": {
-			"version": "7.12.10",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-			"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.10",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.10",
-				"@babel/types": "^7.12.10",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
-			}
-		},
-		"node_modules/@babel/helpers/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+			"integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/node": {
@@ -898,9 +566,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-			"integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+			"integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1580,21 +1248,6 @@
 				"semver": "^5.5.0"
 			}
 		},
-		"node_modules/@babel/preset-env/node_modules/@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-		},
-		"node_modules/@babel/preset-env/node_modules/@babel/types": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-			"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
 		"node_modules/@babel/preset-flow": {
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.12.1.tgz",
@@ -1744,39 +1397,49 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+			"integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
 			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.24.0",
+				"@babel/types": "^7.24.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-			"integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+			"integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
 			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.10.4",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
+				"@babel/code-frame": "^7.24.1",
+				"@babel/generator": "^7.24.1",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.24.1",
+				"@babel/types": "^7.24.0",
+				"debug": "^4.3.1",
+				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-			"integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+			"integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"lodash": "^4.17.13",
+				"@babel/helper-string-parser": "^7.23.4",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@bcoe/v8-coverage": {
@@ -3036,6 +2699,49 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+			"dependencies": {
+				"@jridgewell/set-array": "^1.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
 		"node_modules/@manypkg/find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -3806,39 +3512,6 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
-		"node_modules/autoprefixer/node_modules/browserslist": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-			"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
-			"dependencies": {
-				"caniuse-lite": "^1.0.30001165",
-				"colorette": "^1.2.1",
-				"electron-to-chromium": "^1.3.621",
-				"escalade": "^3.1.1",
-				"node-releases": "^1.1.67"
-			},
-			"bin": {
-				"browserslist": "cli.js"
-			},
-			"engines": {
-				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			}
-		},
-		"node_modules/autoprefixer/node_modules/caniuse-lite": {
-			"version": "1.0.30001168",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-			"integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
-		},
-		"node_modules/autoprefixer/node_modules/electron-to-chromium": {
-			"version": "1.3.628",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.628.tgz",
-			"integrity": "sha512-fmhO4YGo/kapy+xL9Eq/cZwDASaTHZu3psIFYo4yc+RY1LzbZr84xjKlDImDrlrmWhOxsrDi98nX097U/xK/cQ=="
-		},
-		"node_modules/autoprefixer/node_modules/node-releases": {
-			"version": "1.1.67",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
-		},
 		"node_modules/aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -4278,14 +3951,28 @@
 			"dev": true
 		},
 		"node_modules/browserslist": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
-			"integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+			"integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001093",
-				"electron-to-chromium": "^1.3.488",
-				"escalade": "^3.0.1",
-				"node-releases": "^1.1.58"
+				"caniuse-lite": "^1.0.30001587",
+				"electron-to-chromium": "^1.4.668",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.13"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -4432,9 +4119,23 @@
 			"dev": true
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001099",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-			"integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA=="
+			"version": "1.0.30001606",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+			"integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			]
 		},
 		"node_modules/capture-exit": {
 			"version": "2.0.0",
@@ -4960,6 +4661,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -4987,39 +4689,6 @@
 				"browserslist": "^4.15.0",
 				"semver": "7.0.0"
 			}
-		},
-		"node_modules/core-js-compat/node_modules/browserslist": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-			"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
-			"dependencies": {
-				"caniuse-lite": "^1.0.30001165",
-				"colorette": "^1.2.1",
-				"electron-to-chromium": "^1.3.621",
-				"escalade": "^3.1.1",
-				"node-releases": "^1.1.67"
-			},
-			"bin": {
-				"browserslist": "cli.js"
-			},
-			"engines": {
-				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			}
-		},
-		"node_modules/core-js-compat/node_modules/caniuse-lite": {
-			"version": "1.0.30001168",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-			"integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
-		},
-		"node_modules/core-js-compat/node_modules/electron-to-chromium": {
-			"version": "1.3.628",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.628.tgz",
-			"integrity": "sha512-fmhO4YGo/kapy+xL9Eq/cZwDASaTHZu3psIFYo4yc+RY1LzbZr84xjKlDImDrlrmWhOxsrDi98nX097U/xK/cQ=="
-		},
-		"node_modules/core-js-compat/node_modules/node-releases": {
-			"version": "1.1.67",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
 		},
 		"node_modules/core-js-compat/node_modules/semver": {
 			"version": "7.0.0",
@@ -5602,11 +5271,19 @@
 			"dev": true
 		},
 		"node_modules/debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dependencies": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/decamelize": {
@@ -5922,9 +5599,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.496",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.496.tgz",
-			"integrity": "sha512-TXY4mwoyowwi4Lsrq9vcTUYBThyc1b2hXaTZI13p8/FRhY2CTaq5lK+DVjhYkKiTLsKt569Xes+0J5JsVXFurQ=="
+			"version": "1.4.729",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.729.tgz",
+			"integrity": "sha512-bx7+5Saea/qu14kmPTDHQxkp2UnziG3iajUQu3BxFvCOnpAJdDbMV4rSl+EqFDkkpNNVUFlR1kDfpL59xfy1HA=="
 		},
 		"node_modules/emittery": {
 			"version": "0.7.2",
@@ -10557,12 +10234,9 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-			"dependencies": {
-				"minimist": "^1.2.5"
-			},
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -10753,18 +10427,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/lint-staged/node_modules/debug": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
 			}
 		},
 		"node_modules/lint-staged/node_modules/execa": {
@@ -11822,9 +11484,9 @@
 			"optional": true
 		},
 		"node_modules/node-releases": {
-			"version": "1.1.59",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
-			"integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw=="
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
@@ -12889,6 +12551,11 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
+		},
+		"node_modules/picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.2.2",
@@ -16007,6 +15674,7 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -17115,6 +16783,35 @@
 				"yarn": "*"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
@@ -17573,6 +17270,15 @@
 		}
 	},
 	"dependencies": {
+		"@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
 		"@babel/cli": {
 			"version": "7.12.10",
 			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.12.10.tgz",
@@ -17622,115 +17328,62 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
 			"requires": {
-				"@babel/highlight": "^7.10.4"
+				"@babel/highlight": "^7.24.2",
+				"picocolors": "^1.0.0"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.12.7",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
-			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw=="
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+			"integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ=="
 		},
 		"@babel/core": {
-			"version": "7.12.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
-			"integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
+			"integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.10",
-				"@babel/helper-module-transforms": "^7.12.1",
-				"@babel/helpers": "^7.12.5",
-				"@babel/parser": "^7.12.10",
-				"@babel/template": "^7.12.7",
-				"@babel/traverse": "^7.12.10",
-				"@babel/types": "^7.12.10",
-				"convert-source-map": "^1.7.0",
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.24.2",
+				"@babel/generator": "^7.24.4",
+				"@babel/helper-compilation-targets": "^7.23.6",
+				"@babel/helper-module-transforms": "^7.23.3",
+				"@babel/helpers": "^7.24.4",
+				"@babel/parser": "^7.24.4",
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0",
+				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.1",
-				"json5": "^2.1.2",
-				"lodash": "^4.17.19",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
 			},
 			"dependencies": {
-				"@babel/generator": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
-					"requires": {
-						"@babel/types": "^7.12.11",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
+				"convert-source-map": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+					"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
 				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
-					"requires": {
-						"@babel/types": "^7.12.11"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/parser": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
-				},
-				"@babel/template": {
-					"version": "7.12.7",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-					"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/parser": "^7.12.7",
-						"@babel/types": "^7.12.7"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-					"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.10",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.10",
-						"@babel/types": "^7.12.10",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
+				"semver": {
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
 				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-			"integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
+			"integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
 			"requires": {
-				"@babel/types": "^7.10.4",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
-				"source-map": "^0.5.0"
+				"@babel/types": "^7.24.0",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jsesc": "^2.5.1"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -17739,23 +17392,6 @@
 			"integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
 			"requires": {
 				"@babel/types": "^7.12.10"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -17784,62 +17420,37 @@
 				"@babel/helper-annotate-as-pure": "^7.12.10",
 				"@babel/helper-module-imports": "^7.12.5",
 				"@babel/types": "^7.12.11"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
-			"integrity": "sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
 			"requires": {
-				"@babel/compat-data": "^7.12.5",
-				"@babel/helper-validator-option": "^7.12.1",
-				"browserslist": "^4.14.5",
-				"semver": "^5.5.0"
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-validator-option": "^7.23.5",
+				"browserslist": "^4.22.2",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "4.16.0",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-					"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001165",
-						"colorette": "^1.2.1",
-						"electron-to-chromium": "^1.3.621",
-						"escalade": "^3.1.1",
-						"node-releases": "^1.1.67"
+						"yallist": "^3.0.2"
 					}
 				},
-				"caniuse-lite": {
-					"version": "1.0.30001168",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-					"integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
+				"semver": {
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
 				},
-				"electron-to-chromium": {
-					"version": "1.3.628",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.628.tgz",
-					"integrity": "sha512-fmhO4YGo/kapy+xL9Eq/cZwDASaTHZu3psIFYo4yc+RY1LzbZr84xjKlDImDrlrmWhOxsrDi98nX097U/xK/cQ=="
-				},
-				"node-releases": {
-					"version": "1.1.67",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 				}
 			}
 		},
@@ -17872,24 +17483,12 @@
 				"@babel/helper-function-name": "^7.10.4",
 				"@babel/types": "^7.10.5",
 				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
+		},
+		"@babel/helper-environment-visitor": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA=="
 		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.12.1",
@@ -17897,49 +17496,23 @@
 			"integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
 			"requires": {
 				"@babel/types": "^7.12.1"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
-			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -17948,122 +17521,26 @@
 			"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
 			"requires": {
 				"@babel/types": "^7.12.7"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+			"integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
 			"requires": {
-				"@babel/types": "^7.12.5"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/types": "^7.24.0"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+			"integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.12.1",
-				"@babel/helper-replace-supers": "^7.12.1",
-				"@babel/helper-simple-access": "^7.12.1",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.1",
-				"@babel/types": "^7.12.1",
-				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"@babel/generator": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
-					"requires": {
-						"@babel/types": "^7.12.11",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
-					"requires": {
-						"@babel/types": "^7.12.11"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
-				},
-				"@babel/traverse": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-					"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.10",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.10",
-						"@babel/types": "^7.12.10",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					},
-					"dependencies": {
-						"@babel/helper-validator-identifier": {
-							"version": "7.12.11",
-							"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-							"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-						}
-					}
-				}
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.20"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -18072,23 +17549,6 @@
 			"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
 			"requires": {
 				"@babel/types": "^7.12.10"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -18104,23 +17564,6 @@
 				"@babel/helper-annotate-as-pure": "^7.10.4",
 				"@babel/helper-wrap-function": "^7.10.4",
 				"@babel/types": "^7.12.1"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-replace-supers": {
@@ -18132,87 +17575,14 @@
 				"@babel/helper-optimise-call-expression": "^7.12.10",
 				"@babel/traverse": "^7.12.10",
 				"@babel/types": "^7.12.11"
-			},
-			"dependencies": {
-				"@babel/generator": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
-					"requires": {
-						"@babel/types": "^7.12.11",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
-					"requires": {
-						"@babel/types": "^7.12.11"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/parser": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
-				},
-				"@babel/traverse": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-					"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.10",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.10",
-						"@babel/types": "^7.12.10",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
 			"requires": {
-				"@babel/types": "^7.12.1"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
@@ -18221,42 +17591,30 @@
 			"integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
 			"requires": {
 				"@babel/types": "^7.12.1"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.22.5"
 			}
 		},
+		"@babel/helper-string-parser": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+			"integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ=="
+		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
-			"integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw=="
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw=="
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.12.3",
@@ -18270,79 +17628,24 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
-			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
+			"integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
 			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.5",
-				"@babel/types": "^7.12.5"
-			},
-			"dependencies": {
-				"@babel/generator": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
-					"requires": {
-						"@babel/types": "^7.12.11",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
-					"requires": {
-						"@babel/types": "^7.12.11"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/parser": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
-				},
-				"@babel/traverse": {
-					"version": "7.12.10",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
-					"integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
-					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.10",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.10",
-						"@babel/types": "^7.12.10",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.19"
-					}
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
+				"@babel/template": "^7.24.0",
+				"@babel/traverse": "^7.24.1",
+				"@babel/types": "^7.24.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+			"integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			}
 		},
 		"@babel/node": {
@@ -18369,9 +17672,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-			"integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
+			"version": "7.24.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+			"integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.12.1",
@@ -19040,23 +18343,6 @@
 				"@babel/types": "^7.12.11",
 				"core-js-compat": "^3.8.0",
 				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-				},
-				"@babel/types": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
-					"integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.12.11",
-						"lodash": "^4.17.19",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/preset-flow": {
@@ -19186,38 +18472,39 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+			"integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.24.0",
+				"@babel/types": "^7.24.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-			"integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+			"integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.10.4",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
+				"@babel/code-frame": "^7.24.1",
+				"@babel/generator": "^7.24.1",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.24.1",
+				"@babel/types": "^7.24.0",
+				"debug": "^4.3.1",
+				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-			"integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+			"integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"lodash": "^4.17.13",
+				"@babel/helper-string-parser": "^7.23.4",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -20272,6 +19559,40 @@
 				}
 			}
 		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+			"requires": {
+				"@jridgewell/set-array": "^1.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
+		},
+		"@jridgewell/set-array": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
 		"@manypkg/find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -20932,35 +20253,6 @@
 				"fraction.js": "^4.0.12",
 				"normalize-range": "^0.1.2",
 				"postcss-value-parser": "^4.1.0"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "4.16.0",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-					"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
-					"requires": {
-						"caniuse-lite": "^1.0.30001165",
-						"colorette": "^1.2.1",
-						"electron-to-chromium": "^1.3.621",
-						"escalade": "^3.1.1",
-						"node-releases": "^1.1.67"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001168",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-					"integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
-				},
-				"electron-to-chromium": {
-					"version": "1.3.628",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.628.tgz",
-					"integrity": "sha512-fmhO4YGo/kapy+xL9Eq/cZwDASaTHZu3psIFYo4yc+RY1LzbZr84xjKlDImDrlrmWhOxsrDi98nX097U/xK/cQ=="
-				},
-				"node-releases": {
-					"version": "1.1.67",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
-				}
 			}
 		},
 		"aws-sign2": {
@@ -21331,14 +20623,14 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
-			"integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+			"integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001093",
-				"electron-to-chromium": "^1.3.488",
-				"escalade": "^3.0.1",
-				"node-releases": "^1.1.58"
+				"caniuse-lite": "^1.0.30001587",
+				"electron-to-chromium": "^1.4.668",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.13"
 			}
 		},
 		"bser": {
@@ -21456,9 +20748,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001099",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-			"integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA=="
+			"version": "1.0.30001606",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+			"integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -21893,6 +21185,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -21918,33 +21211,6 @@
 				"semver": "7.0.0"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "4.16.0",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-					"integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
-					"requires": {
-						"caniuse-lite": "^1.0.30001165",
-						"colorette": "^1.2.1",
-						"electron-to-chromium": "^1.3.621",
-						"escalade": "^3.1.1",
-						"node-releases": "^1.1.67"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001168",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-					"integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
-				},
-				"electron-to-chromium": {
-					"version": "1.3.628",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.628.tgz",
-					"integrity": "sha512-fmhO4YGo/kapy+xL9Eq/cZwDASaTHZu3psIFYo4yc+RY1LzbZr84xjKlDImDrlrmWhOxsrDi98nX097U/xK/cQ=="
-				},
-				"node-releases": {
-					"version": "1.1.67",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
-				},
 				"semver": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
@@ -22403,11 +21669,11 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
@@ -22659,9 +21925,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.496",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.496.tgz",
-			"integrity": "sha512-TXY4mwoyowwi4Lsrq9vcTUYBThyc1b2hXaTZI13p8/FRhY2CTaq5lK+DVjhYkKiTLsKt569Xes+0J5JsVXFurQ=="
+			"version": "1.4.729",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.729.tgz",
+			"integrity": "sha512-bx7+5Saea/qu14kmPTDHQxkp2UnziG3iajUQu3BxFvCOnpAJdDbMV4rSl+EqFDkkpNNVUFlR1kDfpL59xfy1HA=="
 		},
 		"emittery": {
 			"version": "0.7.2",
@@ -26336,12 +25602,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-			"requires": {
-				"minimist": "^1.2.5"
-			}
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
 		},
 		"jsonfile": {
 			"version": "4.0.0",
@@ -26487,15 +25750,6 @@
 						"path-key": "^3.1.0",
 						"shebang-command": "^2.0.0",
 						"which": "^2.0.1"
-					}
-				},
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
 					}
 				},
 				"execa": {
@@ -27333,9 +26587,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.59",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
-			"integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw=="
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -28164,6 +27418,11 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
+		},
+		"picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
 		},
 		"picomatch": {
 			"version": "2.2.2",
@@ -30664,7 +29923,8 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-resolve": {
 			"version": "0.5.3",
@@ -31560,6 +30820,15 @@
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
 			"dev": true,
 			"optional": true
+		},
+		"update-browserslist-db": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"requires": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			}
 		},
 		"uri-js": {
 			"version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		}
 	},
 	"dependencies": {
-		"@babel/core": "^7.12.10",
+		"@babel/core": "^7.24.4",
 		"@babel/plugin-proposal-class-properties": "7.12.1",
 		"@babel/plugin-syntax-import-meta": "^7.10.4",
 		"@babel/plugin-syntax-jsx": "^7.12.1",


### PR DESCRIPTION
@babel/traverse has a critical vulnerability for version < 7.23.2
<img width="539" alt="image" src="https://github.com/developit/microbundle/assets/3408480/30838843-5f51-4535-b024-6fc239357236">


https://security.snyk.io/vuln/SNYK-JS-BABELTRAVERSE-5962462


I learned of this through a dependabot alert.

I rant the tests and all are perfect still after this upgrade.