### PR TITLE
Update the path to the modern bundle in the example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
   "source": "src/foo.js",             // your source code
   "exports": {
     "require": "./dist/foo.cjs",      // used for require() in Node 12+
-    "default": "./dist/foo.modern.js" // where to generate the modern bundle (see below)
+    "default": "./dist/foo.modern.mjs" // where to generate the modern bundle (see below)
   },
   "main": "./dist/foo.cjs",           // where to generate the CommonJS bundle
   "module": "./dist/foo.module.js",   // where to generate the ESM bundle


### PR DESCRIPTION
In the example path to modern bundle ends with .js, but microbundle generates .mjs file