### PR TITLE
fix: Resolve entries against cwd

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,7 @@ async function getInput({ entries, cwd, source, module }) {
 						(await jsOrTs(cwd, 'index')) ||
 						module,
 		)
-		.map(file => glob(file))
+		.map(file => glob(file, { cwd }))
 		.forEach(file => input.push(...file));
 
 	return input;


### PR DESCRIPTION
https://github.com/preactjs/preact/pull/4677

[`tiny-glob` resolves against `opts.cwd` or `.`](https://www.runpkg.com/?tiny-glob@0.2.9/sync.js#56), and because we don't pass `cwd` into `tiny-glob`, this can result in incorrect file paths when used with Microbundle's `--cwd` flag.