### PR TITLE
ci: update to latest LTS of Node and GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,12 +12,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: compressed-size-action
         uses: preactjs/compressed-size-action@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -15144,6 +15144,7 @@
 			"version": "2.35.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.35.1.tgz",
 			"integrity": "sha512-q5KxEyWpprAIcainhVy6HfRttD9kutQpHbeqDTWnqAFNJotiojetK6uqmcydNMymBEtC4I8bCYR+J3mTMqeaUA==",
+			"peer": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
@@ -16976,6 +16977,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
 			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -29963,6 +29965,7 @@
 			"version": "2.35.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.35.1.tgz",
 			"integrity": "sha512-q5KxEyWpprAIcainhVy6HfRttD9kutQpHbeqDTWnqAFNJotiojetK6uqmcydNMymBEtC4I8bCYR+J3mTMqeaUA==",
+			"peer": true,
 			"requires": {
 				"fsevents": "~2.1.2"
 			},
@@ -31458,7 +31461,8 @@
 		"typescript": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
+			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"peer": true
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",


### PR DESCRIPTION
- Updates `nodejs.yml` to use Node 24, `actions/checkout@v6` and `actions/setup-node@v6
- Updates `release.yml` to use Node 24, `actions/checkout@v6` and `actions/setup-node@v6
- Updates `size.yml` to use  `actions/checkout@v6`
- Run npm install with npm version `11.6.2`