### PR TITLE
feat: Enhance minification options in configuration

### DIFF
--- a/.changeset/spicy-bulldogs-approve.md
+++ b/.changeset/spicy-bulldogs-approve.md
@@ -1,0 +1,5 @@
+---
+'microbundle': patch
+---
+
+Enhance minification config to support more `minify.format` options.

--- a/src/index.js
+++ b/src/index.js
@@ -608,13 +608,18 @@ function createConfig(options, entry, format, writeMeta) {
 									? minifyOptions.compress
 									: minifyOptions.compress || {},
 							),
-							format: {
-								// By default, Terser wraps function arguments in extra parens to trigger eager parsing.
-								// Whether this is a good idea is way too specific to guess, so we optimize for size by default:
-								wrap_func_args: false,
-								comments: /^\s*([@#]__[A-Z]+__\s*$|@cc_on)/,
-								preserve_annotations: true,
-							},
+							format: Object.assign(
+								{
+									// By default, Terser wraps function arguments in extra parens to trigger eager parsing.
+									// Whether this is a good idea is way too specific to guess, so we optimize for size by default:
+									wrap_func_args: false,
+									comments: /^\s*([@#]__[A-Z]+__\s*$|@cc_on)/,
+									preserve_annotations: true,
+								},
+								typeof minifyOptions.format === 'boolean'
+									? minifyOptions.format
+									: minifyOptions.format || {},
+							),
 							module: modern,
 							ecma: modern ? 2017 : 5,
 							toplevel: modern || format === 'cjs' || format === 'es',

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -2174,6 +2174,53 @@ exports[`fixtures build minify-config-boolean with microbundle 5`] = `
 "
 `;
 
+exports[`fixtures build minify-format-config with microbundle 1`] = `
+"Used script: microbundle
+
+Directory tree:
+
+minify-format-config
+  dist
+    minify-format-config.esm.mjs
+    minify-format-config.esm.mjs.map
+    minify-format-config.js
+    minify-format-config.js.map
+    minify-format-config.umd.js
+    minify-format-config.umd.js.map
+  package.json
+  src
+    index.js
+
+
+Build \\"minify-format-config\\" to dist:
+99 B: minify-format-config.js.gz
+82 B: minify-format-config.js.br
+102 B: minify-format-config.esm.mjs.gz
+82 B: minify-format-config.esm.mjs.br
+212 B: minify-format-config.umd.js.gz
+170 B: minify-format-config.umd.js.br"
+`;
+
+exports[`fixtures build minify-format-config with microbundle 2`] = `6`;
+
+exports[`fixtures build minify-format-config with microbundle 3`] = `
+"function o(o,e){return o+e}console.log('\\\\u4f60\\\\u597d\\\\ud83d\\\\udc4b');export default o;
+//# sourceMappingURL=minify-format-config.esm.mjs.map
+"
+`;
+
+exports[`fixtures build minify-format-config with microbundle 4`] = `
+"console.log('\\\\u4f60\\\\u597d\\\\ud83d\\\\udc4b'),module.exports=function(o,e){return o+e};
+//# sourceMappingURL=minify-format-config.js.map
+"
+`;
+
+exports[`fixtures build minify-format-config with microbundle 5`] = `
+"!function(e,n){'object'==typeof exports&&'undefined'!=typeof module?module.exports=n():'function'==typeof define&&define.amd?define(n):(e='undefined'!=typeof globalThis?globalThis:e||self).minifyFormatConfig=n()}(this,function(){return console.log('\\\\u4f60\\\\u597d\\\\ud83d\\\\udc4b'),function(e,n){return e+n}});
+//# sourceMappingURL=minify-format-config.umd.js.map
+"
+`;
+
 exports[`fixtures build minify-path-config with microbundle 1`] = `
 "Used script: microbundle
 

--- a/test/fixtures/minify-format-config/package.json
+++ b/test/fixtures/minify-format-config/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "minify-format-config",
+  "minify": {
+    "format": {
+      "ascii_only": true,
+      "quote_style": 1,
+      "safari10": true
+    }
+  }
+}

--- a/test/fixtures/minify-format-config/src/index.js
+++ b/test/fixtures/minify-format-config/src/index.js
@@ -1,0 +1,11 @@
+/**
+ * Fixture for minify.format options in package.json:
+ * - ascii_only: true  → Unicode (你好👋) escaped as \uXXXX
+ * - quote_style: 1    → single quotes in output
+ * - safari10: true   → Safari 10/11 compatible output
+ */
+console.log("你好👋");
+
+export default function add(a, b) {
+	return a + b;
+}


### PR DESCRIPTION
Updated the minification configuration to support additional format options. Introduced a new fixture for testing minify.format configurations in package.json, including options for ASCII-only output and quote style. Added corresponding test snapshots to validate the changes.